### PR TITLE
Add `mure path` and `mcd` sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ Default search query is `user:{username} is:public fork:false archived:false`
 
 `mure refresh` updates the repository.
 
+### mure path
+
+`mure path` shows the path of the repository for given repository name.
+
+#### Example
+
+```bash
+mure path something # => $HOME/.dev/something
+```
+
+So you can cd directly to the repository by combining with the following shell function.
+
+```shell
+function mcd { local p=$(mure path "$1") && cd "$p" }
+```
+
+```shell
+mcd something  # => Same as `cd $HOME/.dev/something`
+```
+
 ## License
 
 BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ base_dir = "~/.dev"
 
 [github]
 username = "kitsuyui"
+
+[shell]
+cd_shims = "mcd"
+```
+
+### Set up shell environment for mure
+
+Add following script to your shell configuration file such as `~/.bashrc`, `~/.zshrc` or etc.
+
+```sh
+eval $(mure init --shell)
 ```
 
 ### mure clone
@@ -64,31 +75,21 @@ Default search query is `user:{username} is:public fork:false archived:false`
 
 `mure refresh` updates the repository.
 
-### mure path
+### mcd
 
-`mure path` shows the path of the repository for given repository name.
-
-#### Example
-
-```bash
-mure path something # => $HOME/.dev/something
-```
-
-So you can cd directly to the repository by combining with the following shell function.
-
-```shell
-function mcd { local p=$(mure path "$1") && cd "$p" }
-```
+`mcd` is a command line shims for changing directory shortcut.
+mcd enables you to change directory into the repository.
 
 ```shell
 mcd something  # => Same as `cd $HOME/.dev/something`
 ```
 
-You can set the above shims by running the following command during shell initialization:
+You can change the name of the shim by set `shell.cd_shims` in `.mure.toml` to another name.
 
-```sh
-eval $(mure init --shell)
-```
+### mure path
+
+`mure path` shows the path of the repository for given repository name.
+(Internally, `mure path` is used for `mcd` command.)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ function mcd { local p=$(mure path "$1") && cd "$p" }
 mcd something  # => Same as `cd $HOME/.dev/something`
 ```
 
+You can set the above shims by running the following command during shell initialization:
+
+```sh
+eval $(mure init --shell)
+```
+
 ## License
 
 BSD-3-Clause

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod clone;
 pub mod initialize;
 pub mod issues;
+pub mod path;
 pub mod refresh;

--- a/src/app/path/mod.rs
+++ b/src/app/path/mod.rs
@@ -8,6 +8,10 @@ pub fn path(config: &Config, name: &str) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn shell_shims() -> String {
+    "function mcd { local p=$(mure path \"$1\") && cd \"$p\" }\n".to_string()
+}
+
 fn resolve(config: &Config, name: &str) -> Result<PathBuf, Error> {
     let path_ = config.base_path().join(name);
     if path_.is_dir() && path_.exists() {

--- a/src/app/path/mod.rs
+++ b/src/app/path/mod.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+
+use crate::config::{Config, ConfigSupport};
+use crate::mure_error::Error;
+
+pub fn path(config: &Config, name: &str) -> Result<(), Error> {
+    println!("{}", resolve(config, name)?.display());
+    Ok(())
+}
+
+fn resolve(config: &Config, name: &str) -> Result<PathBuf, Error> {
+    let path_ = config.base_path().join(name);
+    if path_.is_dir() && path_.exists() {
+        return Ok(path_);
+    }
+    Err(Error::from_str(
+        format!("{} is not a git repository", path_.display()).as_str(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{Core, GitHub};
+    use mktemp::Temp;
+
+    use super::*;
+
+    #[test]
+    fn test_resolve_path() {
+        let temp = Temp::new_dir().unwrap();
+        let config = Config {
+            core: Core {
+                base_dir: temp.as_path().to_str().unwrap().to_string(),
+            },
+            github: GitHub {
+                username: "".to_string(),
+            },
+        };
+        git2::Repository::init(config.base_path().join("test_repo")).unwrap();
+        let path = resolve(&config, "test_repo").unwrap();
+        assert_eq!(
+            path.to_str().unwrap(),
+            temp.as_path().join("test_repo").to_str().unwrap()
+        );
+
+        // test_repo2 not exist
+        let path2 = resolve(&config, "test_repo2");
+        assert!(path2.is_err());
+        assert!(path2
+            .unwrap_err()
+            .to_string()
+            .ends_with("test_repo2 is not a git repository"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,6 @@ fn main() {
 
 /// Parser
 fn parser() -> App<'static> {
-    // TODO: subcommand "init" to create ~/.mure.toml
     let subcommand_init = App::new("init").about("create ~/.mure.toml");
     let subcommand_refresh = App::new("refresh").about("refresh repository").arg(
         clap::Arg::with_name("repository")

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,20 @@ fn main() {
     let cmd = parser();
     let matches = cmd.get_matches();
     match matches.subcommand() {
-        Some(("init", _)) => match app::initialize::init() {
-            Ok(_) => {
-                println!("Initialized config file");
+        Some(("init", matches)) => {
+            if matches.is_present("shell") {
+                println!("{}", app::path::shell_shims());
+            } else {
+                match app::initialize::init() {
+                    Ok(_) => {
+                        println!("Initialized config file");
+                    }
+                    Err(e) => {
+                        println!("{}", e);
+                    }
+                }
             }
-            Err(e) => {
-                println!("{}", e);
-            }
-        },
+        }
         Some(("refresh", matches)) => {
             let current_dir = std::env::current_dir().unwrap();
             let repo_path = match matches.get_one::<String>("repository") {
@@ -63,7 +69,13 @@ fn main() {
 
 /// Parser
 fn parser() -> App<'static> {
-    let subcommand_init = App::new("init").about("create ~/.mure.toml");
+    let subcommand_init = App::new("init").about("create ~/.mure.toml").arg(
+        clap::Arg::new("shell")
+            .long("shell")
+            .short('s')
+            .help("Output shims for mure. To be evaluated in shell.")
+            .takes_value(false),
+    );
     let subcommand_refresh = App::new("refresh").about("refresh repository").arg(
         clap::Arg::with_name("repository")
             .help("repository to refresh. if not specified, current directory is used")

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,13 @@ fn main() {
                 Err(e) => println!("{}", e),
             }
         }
+        Some(("path", matches)) => {
+            let name = matches.get_one::<String>("name").unwrap();
+            match app::path::path(&config, name) {
+                Ok(_) => (),
+                Err(e) => println!("{}", e),
+            }
+        }
         _ => unreachable!("unreachable!"),
     };
 }
@@ -77,13 +84,20 @@ fn parser() -> App<'static> {
             .required(true)
             .index(1),
     );
+    let subcommand_path = App::new("path").about("show repository path for name").arg(
+        clap::Arg::with_name("name")
+            .help("repository name")
+            .required(true)
+            .index(1),
+    );
     let cmd = clap::Command::new("mure")
         .bin_name("mure")
         .subcommand_required(true)
         .subcommand(subcommand_init)
         .subcommand(subcommand_refresh)
         .subcommand(subcommand_issues)
-        .subcommand(subcommand_clone);
+        .subcommand(subcommand_clone)
+        .subcommand(subcommand_path);
     cmd
 }
 
@@ -120,6 +134,15 @@ fn test_parser() {
     match cmd.get_matches_from_safe(["mure", "clone", "https://github.com/kitsuyui/mure"]) {
         Ok(matches) => {
             assert_eq!(matches.subcommand_name(), Some("clone"));
+        }
+        Err(e) => {
+            unreachable!("{}", e);
+        }
+    }
+    let cmd = parser();
+    match cmd.get_matches_from_safe(["mure", "path", "mure"]) {
+        Ok(matches) => {
+            assert_eq!(matches.subcommand_name(), Some("path"));
         }
         Err(e) => {
             unreachable!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     match matches.subcommand() {
         Some(("init", matches)) => {
             if matches.is_present("shell") {
-                println!("{}", app::path::shell_shims());
+                println!("{}", app::path::shell_shims(&config));
             } else {
                 match app::initialize::init() {
                     Ok(_) => {


### PR DESCRIPTION
Add `mure path` sub-command like:

```bash
mure path something # => $HOME/.dev/something
```

```shell
function mcd { local p=$(mure path "$1") && cd "$p" }
```

```shell
mcd something  # => Same as `cd $HOME/.dev/something`
```
