### PR TITLE
Fix mure refresh bug

### DIFF
--- a/src/app/clone/mod.rs
+++ b/src/app/clone/mod.rs
@@ -19,7 +19,7 @@ pub fn clone(config: &Config, repo_url: &str) -> Result<(), Error> {
     let result = Command::new("git")
         .current_dir(tobe_clone.parent().unwrap())
         .arg("clone")
-        .arg(&repo_url)
+        .arg(repo_url)
         .output()?;
 
     if !result.status.success() {

--- a/src/app/issues/mod.rs
+++ b/src/app/issues/mod.rs
@@ -45,7 +45,7 @@ pub fn show_issues(query: &str) -> Result<(), Error> {
                             "{}\t{}\t{}\t{}",
                             result.number_of_issues,
                             result.number_of_pull_requests,
-                            result.default_branch_name.unwrap_or_else(|| "".to_string()),
+                            result.default_branch_name.unwrap_or_default(),
                             result.url
                         );
                     }

--- a/src/app/refresh/mod.rs
+++ b/src/app/refresh/mod.rs
@@ -21,6 +21,7 @@ pub enum Reason {
 }
 
 pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
+    let mut messages = vec![];
     if !PathBuf::from(repo_path).join(".git").exists() {
         return Ok(RefreshStatus::DoNothing(Reason::NotGitRepository));
     }
@@ -39,15 +40,22 @@ pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
 
     // TODO: origin is hardcoded. If you have multiple remotes, you need to specify which one to use.
     repo.pull_fast_forwarded("origin", &default_branch)?;
+    messages.push(format!(
+        "Pulled from origin/{} into {}",
+        default_branch, default_branch
+    ));
 
     // switch to default branch if current branch is clean
     if repo.is_clean()? {
         // git switch $default_branch
         let result = repo.switch(&default_branch)?;
-        return Ok(RefreshStatus::Update {
-            switch_to_default: true,
-            message: String::from_utf8(result.stdout).unwrap(),
-        });
+        if result.status.success() {
+            messages.push(format!("Switched to {}", default_branch));
+        } else {
+            let message =
+                String::from_utf8(result.stdout).map_err(|e| Error::from_str(&e.to_string()))?;
+            messages.push(message);
+        }
     }
 
     let merged_branches = repo.merged_branches()?;
@@ -58,11 +66,12 @@ pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
 
     for branch in delete_branches {
         repo.delete_branch(branch)?;
+        messages.push(format!("Deleted branch {}", branch));
     }
 
     Ok(RefreshStatus::Update {
         switch_to_default: false,
-        message: String::from(""),
+        message: messages.join("\n"),
     })
 }
 

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 pub fn get_default_branch() -> Result<String, Error> {
     let result = Command::new("gh")
-        .args(&[
+        .args([
             "repo",
             "view",
             "--json",

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,11 @@ fn main() {
                 None => current_dir.to_str().unwrap().to_string(),
             };
             match app::refresh::refresh(&repo_path) {
-                Ok(_) => (),
+                Ok(r) => {
+                    if let app::refresh::RefreshStatus::Update { message, .. } = r {
+                        println!("{}", message);
+                    }
+                }
                 Err(e) => println!("{}", e),
             }
         }


### PR DESCRIPTION
mure refresh has the feature of removing merged branches.
However, in some cases it did not work well.
This pull request fixes it.

Specifically, it means avoiding early returns after judging the repository clean.
This will allow deletion of previously skipped branches to work properly.
