### PR TITLE
`mure refresh` runs `git fetch -p` equivalent

### DIFF
--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -34,6 +34,8 @@ pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
 
     let default_branch = get_default_branch()?;
 
+    repo.fetch_prune()?;
+
     // switch to default branch if current branch is clean
     if repo.is_clean()? {
         // git switch $default_branch

--- a/src/git.rs
+++ b/src/git.rs
@@ -95,6 +95,7 @@ pub trait RepositorySupport {
         remote: &str,
         branch: &str,
     ) -> Result<GitCommandOutput<PullFastForwardStatus>, Error>;
+    fn fetch_prune(&self) -> Result<GitCommandOutput<()>, Error>;
     fn switch(&self, branch: &str) -> Result<GitCommandOutput<()>, Error>;
     fn delete_branch(&self, branch: &str) -> Result<GitCommandOutput<()>, Error>;
     fn command(&self, args: &[&str]) -> Result<RawGitCommandOutput, Error>;
@@ -180,6 +181,10 @@ impl RepositorySupport for Repository {
             raw,
             interpreted_to: status,
         })
+    }
+
+    fn fetch_prune(&self) -> Result<GitCommandOutput<()>, Error> {
+        self.command(&["fetch", "--prune"])?.try_into()
     }
 
     fn switch(&self, branch: &str) -> Result<GitCommandOutput<()>, Error> {


### PR DESCRIPTION
`mure refresh` runs `git fetch -p` equivalent.
`mure refresh` is a command that updates Git repository roughly to the latest state.
`git fetch -p` is required to delete the branch deleted on the remote in the local.

https://github.com/kitsuyui/mure/issues/90
