### PR TITLE
`mure list` displays the list of repositories managed by `mure`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 pub mod clone;
 pub mod initialize;
 pub mod issues;
+pub mod list;
 pub mod path;
 pub mod refresh;

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -1,0 +1,111 @@
+use std::path::PathBuf;
+
+use crate::config::{Config, ConfigSupport};
+use crate::github::repo::RepoInfo;
+use crate::mure_error::Error;
+
+pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
+    let repos = search_mure_repo(config);
+    if repos.is_empty() {
+        println!("No repositories found");
+        return Ok(());
+    }
+    for repo in repos {
+        match repo {
+            Ok(mure_repo) => {
+                if full && path {
+                    #[allow(clippy::expect_used)]
+                    let abpath = mure_repo
+                        .absolute_path
+                        .to_str()
+                        .expect("failed to convert to str");
+                    println!("{}", abpath);
+                } else if full {
+                    println!("{}", mure_repo.repo.name_with_owner());
+                } else if path {
+                    #[allow(clippy::expect_used)]
+                    let relpath = mure_repo
+                        .relative_path
+                        .to_str()
+                        .expect("failed to convert to str");
+                    println!("{}", relpath);
+                } else {
+                    println!("{}", mure_repo.repo.repo);
+                }
+            }
+            Err(e) => {
+                println!("{}", e.message());
+            }
+        }
+    }
+    Ok(())
+}
+
+struct MureRepo {
+    relative_path: PathBuf,
+    absolute_path: PathBuf,
+    repo: RepoInfo,
+}
+
+fn search_mure_repo(config: &Config) -> Vec<Result<MureRepo, Error>> {
+    let mut repos = vec![];
+    match config.base_path().read_dir() {
+        Ok(dir) => {
+            dir.for_each(|entry| {
+                if let Ok(entry) = entry {
+                    let metadata = match std::fs::symlink_metadata(entry.path()) {
+                        Ok(metadata) => metadata,
+                        Err(_) => return,
+                    };
+                    if !metadata.is_symlink() {
+                        return;
+                    }
+                    match read_symlink_as_mure_repo(&entry.path()) {
+                        Ok(mure_repo) => repos.push(Ok(mure_repo)),
+                        Err(e) => repos.push(Err(e)),
+                    }
+                }
+            });
+        }
+        Err(_) => {
+            repos.push(Err(Error::from_str("failed to read dir")));
+        }
+    }
+    repos
+}
+
+fn read_symlink_as_mure_repo(path: &PathBuf) -> Result<MureRepo, Error> {
+    let absolute_path = match std::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return Err(Error::from_str("failed to get absolute path")),
+    };
+    let Some(owner) = absolute_path.parent() else {
+        return Err(Error::from_str("failed to get owner"));
+    };
+    let Some(domain) = owner.parent() else {
+        return Err(Error::from_str("failed to get domain"));
+    };
+    let repo_name = match absolute_path.file_name() {
+        Some(path) => match path.to_str() {
+            Some(path) => path.to_string(),
+            None => return Err(Error::from_str("failed to get repo name")),
+        },
+        None => return Err(Error::from_str("failed to get repo name")),
+    };
+    let repo = match (owner.file_name(), domain.file_name()) {
+        (Some(owner), Some(domain)) => RepoInfo {
+            owner: owner.to_string_lossy().to_string(),
+            domain: domain.to_string_lossy().to_string(),
+            repo: repo_name,
+        },
+        _ => return Err(Error::from_str("failed to get owner or domain")),
+    };
+    Ok(MureRepo {
+        relative_path: path.clone(),
+        absolute_path,
+        repo,
+    })
+}
+
+#[cfg(test)]
+mod tests {}

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -154,4 +154,36 @@ mod tests {
             assert_eq!(mure_repo.repo.repo, "mure");
         }
     }
+
+    #[test]
+    fn test_app() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+
+        let config: Config = toml::from_str(
+            format!(
+                r#"
+            [core]
+            base_dir = "{}"
+
+            [github]
+            username = "kitsuyui"
+
+            [shell]
+            cd_shims = "mcd"
+        "#,
+                temp_dir.to_str().unwrap()
+            )
+            .as_str(),
+        )
+        .unwrap();
+        crate::app::clone::clone(&config, "https://github.com/kitsuyui/mure").unwrap();
+        let repos = search_mure_repo(&config);
+        assert_eq!(repos.len(), 1);
+
+        // list doesn't panic
+        list(&config, false, false).unwrap();
+        list(&config, true, false).unwrap();
+        list(&config, false, true).unwrap();
+        list(&config, true, true).unwrap();
+    }
 }

--- a/src/github/repo.rs
+++ b/src/github/repo.rs
@@ -16,6 +16,16 @@ impl RepoInfo {
             repo: repo.to_string(),
         }
     }
+
+    #[allow(dead_code)]
+    pub fn fully_qualified_name(&self) -> String {
+        format!("{}/{}/{}", self.domain, self.owner, self.repo)
+    }
+
+    pub fn name_with_owner(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+
     pub fn parse_url(url: &str) -> Option<Self> {
         let patterns = [
             GITHUB_HTTPS_URL.clone(),
@@ -87,5 +97,12 @@ mod tests {
         assert!(parse("https://example.com/something/else").is_none());
         assert!(parse("git@example.com:kitsuyui/mure.git").is_none());
         assert!(parse("ssh://git@example.com/kitsuyui/mure.git").is_none());
+    }
+
+    #[test]
+    fn test_names() {
+        let repo_info = RepoInfo::new("github.com", "kitsuyui", "mure");
+        assert_eq!(repo_info.fully_qualified_name(), "github.com/kitsuyui/mure");
+        assert_eq!(repo_info.name_with_owner(), "kitsuyui/mure");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,10 @@ fn main() -> Result<(), mure_error::Error> {
             Ok(_) => (),
             Err(e) => println!("{}", e),
         },
+        List { path, full } => match app::list::list(&config, path, full) {
+            Ok(_) => (),
+            Err(e) => println!("{}", e),
+        },
     }
     Ok(())
 }
@@ -104,6 +108,13 @@ enum Commands {
     Path {
         #[arg(index = 1, help = "repository name")]
         name: String,
+    },
+    #[command(about = "list repositories")]
+    List {
+        #[arg(short, long, help = "show full name")]
+        full: bool,
+        #[arg(short, long, help = "show path")]
+        path: bool,
     },
 }
 
@@ -164,6 +175,50 @@ fn test_parser() {
         Cli {
             command: Commands::Path { name },
         } => assert_eq!(name, "mure"),
+        _ => panic!("failed to parse"),
+    }
+
+    match Cli::parse_from(vec!["mure", "list"]) {
+        Cli {
+            command:
+                Commands::List {
+                    full: false,
+                    path: false,
+                },
+        } => (),
+        _ => panic!("failed to parse"),
+    }
+
+    match Cli::parse_from(vec!["mure", "list", "--full"]) {
+        Cli {
+            command:
+                Commands::List {
+                    full: true,
+                    path: false,
+                },
+        } => (),
+        _ => panic!("failed to parse"),
+    }
+
+    match Cli::parse_from(vec!["mure", "list", "--path"]) {
+        Cli {
+            command:
+                Commands::List {
+                    full: false,
+                    path: true,
+                },
+        } => (),
+        _ => panic!("failed to parse"),
+    }
+
+    match Cli::parse_from(vec!["mure", "list", "--full", "--path"]) {
+        Cli {
+            command:
+                Commands::List {
+                    full: true,
+                    path: true,
+                },
+        } => (),
         _ => panic!("failed to parse"),
     }
 }


### PR DESCRIPTION
`mure list` displays the list of repositories managed by `mure`.
If you add the `--path` option, it displays the repository path.
If you add the `--full` option, it displays the full path of the repository.

```sh
$ mure list
mure
rust-playground
ml-playground
happy-commit
```

```sh
$ mure list --path
/Users/yui/.dev/mure
/Users/yui/.dev/rust-playground
/Users/yui/.dev/ml-playground
/Users/yui/.dev/happy-commit
```

```sh
$ mure list --path --full
/Users/yui/.dev/repo/github.com/kitsuyui/mure
/Users/yui/.dev/repo/github.com/kitsuyui/rust-playground
/Users/yui/.dev/repo/github.com/kitsuyui/ml-playground
/Users/yui/.dev/repo/github.com/kitsuyui/happy-commit
```

```sh
$ mure list --full
kitsuyui/mure
kitsuyui/rust-playground
kitsuyui/ml-playground
kitsuyui/happy-commit
```
