### PR TITLE
`mure refresh --all` updates all repositories

### DIFF
--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -41,13 +41,13 @@ pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
     Ok(())
 }
 
-struct MureRepo {
-    relative_path: PathBuf,
-    absolute_path: PathBuf,
-    repo: RepoInfo,
+pub struct MureRepo {
+    pub relative_path: PathBuf,
+    pub absolute_path: PathBuf,
+    pub repo: RepoInfo,
 }
 
-fn search_mure_repo(config: &Config) -> Vec<Result<MureRepo, Error>> {
+pub fn search_mure_repo(config: &Config) -> Vec<Result<MureRepo, Error>> {
     let mut repos = vec![];
     match config.base_path().read_dir() {
         Ok(dir) => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,86 +1,13 @@
-use git2::{BranchType, Repository};
-use std::{
-    path::Path,
-    process::{Command, Output},
-    string::FromUtf8Error,
-};
-
+use crate::misc::command_wrapper::{CommandOutput as GitCommandOutput, Error, RawCommandOutput};
 use crate::mure_error;
+use git2::{BranchType, Repository};
+use std::{path::Path, process::Command, string::FromUtf8Error};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum PullFastForwardStatus {
     AlreadyUpToDate,
     FastForwarded,
     Abort,
-}
-
-#[derive(Debug)]
-pub struct RawGitCommandOutput {
-    pub status: i32,
-    pub stdout: String,
-    pub stderr: String,
-}
-
-impl RawGitCommandOutput {
-    pub fn success(&self) -> bool {
-        self.status == 0
-    }
-}
-
-impl From<std::process::Output> for RawGitCommandOutput {
-    fn from(output: Output) -> Self {
-        let status = output.status.code().unwrap_or(-1);
-        let stdout = String::from_utf8(output.stdout).unwrap_or_default();
-        let stderr = String::from_utf8(output.stderr).unwrap_or_default();
-        RawGitCommandOutput {
-            status,
-            stdout,
-            stderr,
-        }
-    }
-}
-
-impl TryFrom<RawGitCommandOutput> for GitCommandOutput<()> {
-    type Error = Error;
-
-    fn try_from(raw: RawGitCommandOutput) -> Result<Self, Self::Error> {
-        match raw.success() {
-            true => raw.interpret_to(()),
-            false => Err(Error::Raw(raw)),
-        }
-    }
-}
-
-impl RawGitCommandOutput {
-    pub fn interpret_to<T>(self, item: T) -> Result<GitCommandOutput<T>, Error> {
-        Ok(GitCommandOutput {
-            raw: self,
-            interpreted_to: item,
-        })
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Raw(raw) => write!(f, "{}", raw.stderr),
-            Error::FailedToExecute(err) => write!(f, "Failed to execute git command: {}", err),
-            Error::CommandNotFound => write!(f, "git command not found"),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum Error {
-    Raw(RawGitCommandOutput),
-    FailedToExecute(std::io::Error),
-    CommandNotFound,
-}
-
-#[derive(Debug)]
-pub struct GitCommandOutput<T> {
-    pub raw: RawGitCommandOutput,
-    pub interpreted_to: T,
 }
 
 pub trait RepositorySupport {
@@ -98,8 +25,8 @@ pub trait RepositorySupport {
     fn fetch_prune(&self) -> Result<GitCommandOutput<()>, Error>;
     fn switch(&self, branch: &str) -> Result<GitCommandOutput<()>, Error>;
     fn delete_branch(&self, branch: &str) -> Result<GitCommandOutput<()>, Error>;
-    fn command(&self, args: &[&str]) -> Result<RawGitCommandOutput, Error>;
-    fn git_command_on_dir(args: &[&str], workdir: &Path) -> Result<RawGitCommandOutput, Error>;
+    fn command(&self, args: &[&str]) -> Result<RawCommandOutput, Error>;
+    fn git_command_on_dir(args: &[&str], workdir: &Path) -> Result<RawCommandOutput, Error>;
 }
 
 impl RepositorySupport for Repository {
@@ -195,17 +122,20 @@ impl RepositorySupport for Repository {
         self.command(&["branch", "-d", branch])?.try_into()
     }
 
-    fn git_command_on_dir(args: &[&str], workdir: &Path) -> Result<RawGitCommandOutput, Error> {
+    fn git_command_on_dir(args: &[&str], workdir: &Path) -> Result<RawCommandOutput, Error> {
         let output = Command::new("git").current_dir(workdir).args(args).output();
         match output {
-            Ok(out) => Ok(RawGitCommandOutput::from(out)),
+            Ok(out) => Ok(RawCommandOutput::from(out)),
             Err(err) => Err(Error::FailedToExecute(err)),
         }
     }
 
-    fn command(&self, args: &[&str]) -> Result<RawGitCommandOutput, Error> {
+    fn command(&self, args: &[&str]) -> Result<RawCommandOutput, Error> {
         let Some(workdir) = self.workdir() else {
-            return Err(Error::CommandNotFound);
+            return Err(Error::FailedToExecute(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "workdir is not found",
+            )));
         };
         Self::git_command_on_dir(args, workdir)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod gh;
 mod git;
 mod github;
+mod misc;
 mod mure_error;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,22 +27,26 @@ fn main() -> Result<(), mure_error::Error> {
                 println!("{}", e);
             }
         },
-        Refresh { repository } => {
-            let current_dir = std::env::current_dir()?;
-            let Some(current_dir) = current_dir.to_str() else {
+        Refresh { repository, all } => {
+            if all {
+                app::refresh::refresh_all(&config)?;
+            } else {
+                let current_dir = std::env::current_dir()?;
+                let Some(current_dir) = current_dir.to_str() else {
                 return Err(mure_error::Error::from_str("failed to get current dir"));
             };
-            let repo_path = match repository {
-                Some(repo) => repo,
-                None => current_dir.to_string(),
-            };
-            match app::refresh::refresh(&repo_path) {
-                Ok(r) => {
-                    if let app::refresh::RefreshStatus::Update { message, .. } = r {
-                        println!("{}", message);
+                let repo_path = match repository {
+                    Some(repo) => repo,
+                    None => current_dir.to_string(),
+                };
+                match app::refresh::refresh(&repo_path) {
+                    Ok(r) => {
+                        if let app::refresh::RefreshStatus::Update { message, .. } = r {
+                            println!("{}", message);
+                        }
                     }
+                    Err(e) => println!("{}", e),
                 }
-                Err(e) => println!("{}", e),
             }
         }
         Issues { query } => {
@@ -94,6 +98,13 @@ enum Commands {
             help = "repository to refresh. if not specified, current directory is used"
         )]
         repository: Option<String>,
+        #[arg(
+            short,
+            long,
+            help = "refresh all repositories",
+            default_value = "false"
+        )]
+        all: bool,
     },
     #[command(about = "show issues")]
     Issues {
@@ -137,17 +148,34 @@ fn test_parser() {
 
     match Cli::parse_from(vec!["mure", "refresh"]) {
         Cli {
-            command: Commands::Refresh { repository: None },
+            command:
+                Commands::Refresh {
+                    repository: None,
+                    all: false,
+                },
         } => (),
         _ => panic!("failed to parse"),
     }
 
     match Cli::parse_from(vec!["mure", "refresh", "react"]) {
         Cli {
-            command: Commands::Refresh {
-                repository: Some(repo),
-            },
+            command:
+                Commands::Refresh {
+                    repository: Some(repo),
+                    all: false,
+                },
         } => assert_eq!(repo, "react"),
+        _ => panic!("failed to parse"),
+    }
+
+    match Cli::parse_from(vec!["mure", "refresh", "--all"]) {
+        Cli {
+            command:
+                Commands::Refresh {
+                    repository: None,
+                    all: true,
+                },
+        } => (),
         _ => panic!("failed to parse"),
     }
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,0 +1,1 @@
+pub mod command_wrapper;

--- a/src/misc/command_wrapper.rs
+++ b/src/misc/command_wrapper.rs
@@ -1,0 +1,132 @@
+/// ## Description: A wrapper around std::process::Command to make it easier to use
+/// ## Problem
+///
+/// In Rust, I want to express the result as a simple enum or struct as much as possible.
+/// On the other hand, the result of a normal command is expressed by exit code and stdout, stderr.
+/// The meaning of exit code and stderr varies depending on the command.
+///
+/// - Example 1. Most commands return 0 for success and anything else for failure.
+/// - Example 2. The diff command for finding text differences returns 0 if there is no difference, 1 if there is a difference, and 2 if it fails.
+/// - Example 3. git pull returns 0 if it is already up to date, but outputs "Already up to date" to stderr.
+///
+/// Since the meaning of exit code and stderr varies depending on the command, it cannot be expressed as a Rust Error.
+/// If the return value is within the scope of the command, it should be expressed as an enum, and it is not appropriate to express it as a Rust Error.
+/// The cases that should be expressed as a Rust Error are cases where the prerequisites of the command are not met.
+/// For example,
+///
+/// - Example 1. The command is not installed
+/// - Example 2. The environment variable required to execute the command is not set
+/// - Example 3. An argument that the command cannot interpret is given
+///
+/// ## Solution provided by the wrapper
+///
+/// - This command wrapper expresses the result of the command as a RawCommandOutput struct.
+/// - The type to be handled primarily in Rust is T.
+/// - CommandOutput <T> holds both RawCommandOutput and the result of the command converted to T.
+/// - Error holds RawCommandOutput.
+use std::process::Output;
+
+#[derive(Debug)]
+pub enum Error {
+    Raw(RawCommandOutput),
+    FailedToExecute(std::io::Error),
+}
+
+#[derive(Debug)]
+pub struct CommandOutput<T> {
+    pub raw: RawCommandOutput,
+    pub interpreted_to: T,
+}
+
+#[derive(Debug)]
+pub struct RawCommandOutput {
+    pub status: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl RawCommandOutput {
+    pub fn success(&self) -> bool {
+        self.status == 0
+    }
+}
+
+impl From<std::process::Output> for RawCommandOutput {
+    fn from(output: Output) -> Self {
+        let status = output.status.code().unwrap_or(-1);
+        let stdout = String::from_utf8(output.stdout).unwrap_or_default();
+        let stderr = String::from_utf8(output.stderr).unwrap_or_default();
+        RawCommandOutput {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+impl TryFrom<RawCommandOutput> for CommandOutput<()> {
+    type Error = Error;
+
+    fn try_from(raw: RawCommandOutput) -> Result<Self, Self::Error> {
+        match raw.success() {
+            true => raw.interpret_to(()),
+            false => Err(Error::Raw(raw)),
+        }
+    }
+}
+
+impl TryFrom<Result<std::process::Output, std::io::Error>> for RawCommandOutput {
+    type Error = Error;
+
+    fn try_from(result: Result<std::process::Output, std::io::Error>) -> Result<Self, Self::Error> {
+        match result {
+            Ok(output) => Ok(RawCommandOutput::from(output)),
+            Err(err) => Err(Error::FailedToExecute(err)),
+        }
+    }
+}
+
+impl RawCommandOutput {
+    pub fn interpret_to<T>(self, item: T) -> Result<CommandOutput<T>, Error> {
+        Ok(CommandOutput {
+            raw: self,
+            interpreted_to: item,
+        })
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Raw(raw) => write!(f, "{}", raw.stderr),
+            Error::FailedToExecute(err) => write!(f, "Failed to execute command: {}", err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn test_command_wrapper() {
+        // success
+        let output = Command::new("ls").arg("hello").output();
+        let raw = RawCommandOutput::try_from(output);
+        assert!(raw.is_ok());
+        let raw = raw.unwrap();
+        assert!(!raw.success());
+
+        // fail: command not found
+        let output = Command::new("nothing").arg("hello").output();
+        let raw = RawCommandOutput::try_from(output);
+        assert!(raw.is_err());
+        let err = raw.err().unwrap();
+        assert_eq!(
+            err.to_string(),
+            "Failed to execute command: No such file or directory (os error 2)"
+        );
+    }
+}

--- a/src/mure_error.rs
+++ b/src/mure_error.rs
@@ -40,8 +40,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<crate::git::Error> for Error {
-    fn from(e: crate::git::Error) -> Error {
+impl From<crate::misc::command_wrapper::Error> for Error {
+    fn from(e: crate::misc::command_wrapper::Error) -> Error {
         Error::GitCommandError(e.to_string())
     }
 }

--- a/src/test_fixture.rs
+++ b/src/test_fixture.rs
@@ -3,10 +3,8 @@ use std::io::Write;
 use git2::Repository;
 use mktemp::Temp;
 
-use crate::{
-    git::{GitCommandOutput, RepositorySupport},
-    mure_error::Error,
-};
+use crate::misc::command_wrapper::CommandOutput;
+use crate::{git::RepositorySupport, mure_error::Error};
 
 #[cfg(test)]
 pub struct Fixture {
@@ -47,7 +45,7 @@ impl Fixture {
     pub fn create_empty_commit(
         &self,
         message: &str,
-    ) -> Result<GitCommandOutput<()>, crate::git::Error> {
+    ) -> Result<CommandOutput<()>, crate::misc::command_wrapper::Error> {
         self.repo
             .command(&["commit", "--allow-empty", "-m", message])?
             .interpret_to(())


### PR DESCRIPTION
`mure refresh --all` updates all repositories.
`mure refresh` updates the repository in the current directory by default.
If you add the `--all` option, it updates all repositories managed by `mure`.
