### PR TITLE
Fix: uninlined_format_args

### DIFF
--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -39,7 +39,7 @@ pub fn show_issues(query: &str) -> Result<(), Error> {
     };
 
     match github::api::search_all_repositories(&token, query) {
-        Err(e) => println!("{}", e),
+        Err(e) => println!("{e}"),
         Ok(result) => {
             match repository_summary(result) {
                 Ok(results) => {
@@ -55,7 +55,7 @@ pub fn show_issues(query: &str) -> Result<(), Error> {
                         );
                     }
                 }
-                Err(e) => println!("{}", e),
+                Err(e) => println!("{e}"),
             }
         }
     };

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -19,7 +19,7 @@ pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
                         .absolute_path
                         .to_str()
                         .expect("failed to convert to str");
-                    println!("{}", abpath);
+                    println!("{abpath}");
                 } else if full {
                     println!("{}", mure_repo.repo.name_with_owner());
                 } else if path {
@@ -28,7 +28,7 @@ pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
                         .relative_path
                         .to_str()
                         .expect("failed to convert to str");
-                    println!("{}", relpath);
+                    println!("{relpath}");
                 } else {
                     println!("{}", mure_repo.repo.repo);
                 }

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -14,11 +14,7 @@ pub fn shell_shims(config: &Config) -> String {
 }
 
 fn shell_shims_for_cd_directly(bin_name: &str, fn_name: &str) -> String {
-    format!(
-        "function {fn_name}() {{ local p=$({bin_name} path \"$1\") && cd \"$p\" }}\n",
-        fn_name = fn_name,
-        bin_name = bin_name
-    )
+    format!("function {fn_name}() {{ local p=$({bin_name} path \"$1\") && cd \"$p\" }}\n")
 }
 
 fn resolve(config: &Config, name: &str) -> Result<PathBuf, Error> {

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -58,7 +58,7 @@ pub fn refresh_all(config: &Config) -> Result<(), Error> {
                             if switch_to_default {
                                 println!("Switched to {}", mure_repo.repo.repo)
                             }
-                            println!("{}", message)
+                            println!("{message}")
                         }
                     },
                     Err(e) => {
@@ -93,7 +93,7 @@ pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
     if repo.is_clean()? {
         // git switch $default_branch
         repo.switch(&default_branch)?;
-        messages.push(format!("Switched to {}", default_branch));
+        messages.push(format!("Switched to {default_branch}"));
     }
 
     // TODO: origin is hardcoded. If you have multiple remotes, you need to specify which one to use.
@@ -122,7 +122,7 @@ pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
 
     for branch in delete_branches {
         repo.delete_branch(branch)?;
-        messages.push(format!("Deleted branch {}", branch));
+        messages.push(format!("Deleted branch {branch}"));
     }
 
     Ok(RefreshStatus::Update {

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_resolve_config_path() {
         let home = std::env::var("HOME").unwrap();
         match resolve_config_path() {
-            Ok(path) => assert_eq!(path.to_str().unwrap(), &format!("{}/.mure.toml", home)),
+            Ok(path) => assert_eq!(path.to_str().unwrap(), &format!("{home}/.mure.toml")),
             Err(err) => unreachable!("{:?}", err),
         }
     }

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -73,7 +73,7 @@ fn search_repositories(
     let request_body = SearchRepositoryQuery::build_query(variables);
     let client = reqwest::blocking::Client::new();
     let url = "https://api.github.com/graphql";
-    let bearer = format!("bearer {}", token);
+    let bearer = format!("bearer {token}");
     let res = client
         .post(url)
         .header("Authorization", bearer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), mure_error::Error> {
                 println!("Initialized config file");
             }
             Err(e) => {
-                println!("{}", e);
+                println!("{e}");
             }
         },
         Refresh { repository, all } => {
@@ -42,10 +42,10 @@ fn main() -> Result<(), mure_error::Error> {
                 match app::refresh::refresh(&repo_path) {
                     Ok(r) => {
                         if let app::refresh::RefreshStatus::Update { message, .. } = r {
-                            println!("{}", message);
+                            println!("{message}");
                         }
                     }
-                    Err(e) => println!("{}", e),
+                    Err(e) => println!("{e}"),
                 }
             }
         }
@@ -57,20 +57,20 @@ fn main() -> Result<(), mure_error::Error> {
             let query = query.unwrap_or_else(|| default_query.to_string());
             match app::issues::show_issues(&query) {
                 Ok(_) => (),
-                Err(e) => println!("{}", e),
+                Err(e) => println!("{e}"),
             }
         }
         Clone { url } => match app::clone::clone(&config, &url) {
             Ok(_) => (),
-            Err(e) => println!("{}", e),
+            Err(e) => println!("{e}"),
         },
         Path { name } => match app::path::path(&config, &name) {
             Ok(_) => (),
-            Err(e) => println!("{}", e),
+            Err(e) => println!("{e}"),
         },
         List { path, full } => match app::list::list(&config, path, full) {
             Ok(_) => (),
-            Err(e) => println!("{}", e),
+            Err(e) => println!("{e}"),
         },
     }
     Ok(())

--- a/src/misc/command_wrapper.rs
+++ b/src/misc/command_wrapper.rs
@@ -99,7 +99,7 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Raw(raw) => write!(f, "{}", raw.stderr),
-            Error::FailedToExecute(err) => write!(f, "Failed to execute command: {}", err),
+            Error::FailedToExecute(err) => write!(f, "Failed to execute command: {err}"),
         }
     }
 }


### PR DESCRIPTION
inline format is easier to read and understand.
This is moved to warn-by-default from Rust 1.67 and clippy.
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
