### PR TITLE
Rename mcd to mucd

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ base_dir = "~/.dev"
 username = "kitsuyui"
 
 [shell]
-cd_shims = "mcd"
+cd_shims = "mucd"
 ```
 
 ### Set up shell environment for mure
@@ -77,13 +77,13 @@ Default search query is `user:{username} is:public fork:false archived:false`
 
 `mure refresh` updates the repository.
 
-### mcd
+### mucd
 
-`mcd` is a command line shims for changing directory shortcut.
-mcd enables you to change directory into the repository.
+`mucd` is a command line shims for changing directory shortcut.
+mucd enables you to change directory into the repository.
 
 ```shell
-mcd something  # => Same as `cd $HOME/.dev/something`
+mucd something  # => Same as `cd $HOME/.dev/something`
 ```
 
 You can change the name of the shim by set `shell.cd_shims` in `.mure.toml` to another name.
@@ -91,7 +91,7 @@ You can change the name of the shim by set `shell.cd_shims` in `.mure.toml` to a
 ### mure path
 
 `mure path` shows the path of the repository for given repository name.
-(Internally, `mure path` is used for `mcd` command.)
+(Internally, `mure path` is used for `mucd` command.)
 
 ### Setup shell completion
 

--- a/src/app/clone.rs
+++ b/src/app/clone.rs
@@ -45,7 +45,7 @@ mod tests {
         username = "kitsuyui"
 
         [shell]
-        cd_shims = "mcd"
+        cd_shims = "mucd"
     "#,
             temp_dir.as_os_str().to_str().unwrap()
         );

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -127,7 +127,7 @@ mod tests {
             username = "kitsuyui"
 
             [shell]
-            cd_shims = "mcd"
+            cd_shims = "mucd"
         "#,
                 temp_dir.to_str().unwrap()
             )
@@ -169,7 +169,7 @@ mod tests {
             username = "kitsuyui"
 
             [shell]
-            cd_shims = "mcd"
+            cd_shims = "mucd"
         "#,
                 temp_dir.to_str().unwrap()
             )

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -45,7 +45,7 @@ mod tests {
                 username: "".to_string(),
             },
             shell: Some(Shell {
-                cd_shims: Some("mcd".to_string()),
+                cd_shims: Some("mucd".to_string()),
             }),
         };
         git2::Repository::init(config.base_path().join("test_repo")).unwrap();
@@ -74,13 +74,13 @@ mod tests {
                 username: "".to_string(),
             },
             shell: Some(Shell {
-                cd_shims: Some("mcd".to_string()),
+                cd_shims: Some("mucd".to_string()),
             }),
         };
         let shims = shell_shims(&config);
         assert_eq!(
             shims,
-            "function mcd() { local p=$(mure path \"$1\") && cd \"$p\" }\n"
+            "function mucd() { local p=$(mure path \"$1\") && cd \"$p\" }\n"
         );
     }
 }

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -229,7 +229,7 @@ mod tests {
             username = "kitsuyui"
 
             [shell]
-            cd_shims = "mcd"
+            cd_shims = "mucd"
         "#,
                 temp_dir.to_str().unwrap()
             )

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,7 @@ impl ConfigSupport for Config {
         self.base_path().join(repo)
     }
     fn resolve_cd_shims(&self) -> String {
-        let default = "mcd".to_string();
+        let default = "mucd".to_string();
         match &self.shell {
             Some(shell) => shell.cd_shims.clone().unwrap_or(default),
             None => default,
@@ -92,7 +92,7 @@ fn create_config(path: &Path) -> Result<Config, Error> {
             username: "".to_string(),
         },
         shell: Some(Shell {
-            cd_shims: Some("mcd".to_string()),
+            cd_shims: Some("mucd".to_string()),
         }),
     };
     let content = toml::to_string(&config)?;
@@ -149,7 +149,7 @@ mod tests {
             username = "kitsuyui"
 
             [shell]
-            cd_shims = "mcd"
+            cd_shims = "mucd"
         "#,
         )
         .unwrap();


### PR DESCRIPTION
The `mcd` command is an abbreviation of `mure cd`, and when executed as `mcd repository name`, it moves to the directory of that repository.
This is enabled by `eval $(mure init --shell)`.
This `mcd` command may conflict with another command.

Rename it. (Close: #126)
