### PR TITLE
Feature: -q --quiet and -v --verbose

### DIFF
--- a/src/app/clone.rs
+++ b/src/app/clone.rs
@@ -1,11 +1,12 @@
 use crate::config::Config;
 use crate::git::RepositorySupport;
 use crate::github::repo::RepoInfo;
+use crate::verbosity::Verbosity;
 use crate::{config::ConfigSupport, mure_error::Error};
 use std::fs as std_fs;
 use std::os::unix::fs as unix_fs;
 
-pub fn clone(config: &Config, repo_url: &str) -> Result<(), Error> {
+pub fn clone(config: &Config, repo_url: &str, _verbosity: Verbosity) -> Result<(), Error> {
     let parsed = RepoInfo::parse_url(repo_url);
     let Some(repo_info) = parsed else {
         return Err(Error::from_str("invalid repo url"));
@@ -51,13 +52,17 @@ mod tests {
         );
         let config: Config = toml::from_str(&config_file).unwrap();
 
-        match clone(&config, "https://github.com/kitsuyui/mure") {
+        match clone(
+            &config,
+            "https://github.com/kitsuyui/mure",
+            Verbosity::Normal,
+        ) {
             Ok(_) => {}
             Err(_) => unreachable!(),
         }
         let config: Config = toml::from_str(&config_file).unwrap();
 
-        let Err(error) = clone(&config, "") else {
+        let Err(error) = clone(&config, "", Verbosity::Normal) else {
             unreachable!();
         };
         assert_eq!(error.to_string(), "invalid repo url");

--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -2,8 +2,13 @@ use crate::config::Config;
 use crate::github;
 use crate::github::api::search_repository_query::SearchRepositoryQueryReposEdgesNodeOnRepository;
 use crate::mure_error::Error;
+use crate::verbosity::Verbosity;
 
-pub fn show_issues_main(config: &Config, query: Option<String>) -> Result<(), Error> {
+pub fn show_issues_main(
+    config: &Config,
+    query: Option<String>,
+    _verbosity: Verbosity,
+) -> Result<(), Error> {
     let default_query = format!(
         "user:{} is:public fork:false archived:false",
         &config.github.username

--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -2,13 +2,8 @@ use crate::config::Config;
 use crate::github;
 use crate::github::api::search_repository_query::SearchRepositoryQueryReposEdgesNodeOnRepository;
 use crate::mure_error::Error;
-use crate::verbosity::Verbosity;
 
-pub fn show_issues_main(
-    config: &Config,
-    query: Option<String>,
-    _verbosity: Verbosity,
-) -> Result<(), Error> {
+pub fn show_issues_main(config: &Config, query: Option<String>) -> Result<(), Error> {
     let default_query = format!(
         "user:{} is:public fork:false archived:false",
         &config.github.username

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -111,6 +111,8 @@ fn read_symlink_as_mure_repo(path: &PathBuf) -> Result<MureRepo, Error> {
 mod tests {
     use mktemp::Temp;
 
+    use crate::verbosity::Verbosity;
+
     use super::*;
 
     #[test]
@@ -136,7 +138,12 @@ mod tests {
         .unwrap();
         let repos = search_mure_repo(&config);
         assert_eq!(repos.len(), 0);
-        crate::app::clone::clone(&config, "https://github.com/kitsuyui/mure").unwrap();
+        crate::app::clone::clone(
+            &config,
+            "https://github.com/kitsuyui/mure",
+            Verbosity::Normal,
+        )
+        .unwrap();
 
         let repos = search_mure_repo(&config);
         assert_eq!(repos.len(), 1);
@@ -176,7 +183,12 @@ mod tests {
             .as_str(),
         )
         .unwrap();
-        crate::app::clone::clone(&config, "https://github.com/kitsuyui/mure").unwrap();
+        crate::app::clone::clone(
+            &config,
+            "https://github.com/kitsuyui/mure",
+            Verbosity::Normal,
+        )
+        .unwrap();
         let repos = search_mure_repo(&config);
         assert_eq!(repos.len(), 1);
 

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -6,10 +6,16 @@ use crate::config::Config;
 use crate::gh::get_default_branch;
 use crate::git::{PullFastForwardStatus, RepositorySupport};
 use crate::mure_error::Error;
+use crate::verbosity::Verbosity;
 
 use super::list::search_mure_repo;
 
-pub fn refresh_main(config: &Config, all: bool, repository: Option<String>) -> Result<(), Error> {
+pub fn refresh_main(
+    config: &Config,
+    all: bool,
+    repository: Option<String>,
+    _verbosity: Verbosity,
+) -> Result<(), Error> {
     if all {
         refresh_all(config)?;
     } else {
@@ -262,7 +268,12 @@ mod tests {
         .unwrap();
         let repos = search_mure_repo(&config);
         assert_eq!(repos.len(), 0);
-        crate::app::clone::clone(&config, "https://github.com/kitsuyui/mure").unwrap();
+        crate::app::clone::clone(
+            &config,
+            "https://github.com/kitsuyui/mure",
+            Verbosity::Normal,
+        )
+        .unwrap();
 
         refresh_all(&config).unwrap();
     }

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -14,10 +14,10 @@ pub fn refresh_main(
     config: &Config,
     all: bool,
     repository: Option<String>,
-    _verbosity: Verbosity,
+    verbosity: Verbosity,
 ) -> Result<(), Error> {
     if all {
-        refresh_all(config)?;
+        refresh_all(config, verbosity)?;
     } else {
         let current_dir = std::env::current_dir()?;
         let Some(current_dir) = current_dir.to_str() else {
@@ -27,7 +27,7 @@ pub fn refresh_main(
             Some(repo) => repo,
             None => current_dir.to_string(),
         };
-        match refresh(&repo_path) {
+        match refresh(&repo_path, verbosity) {
             Ok(r) => {
                 if let RefreshStatus::Update { message, .. } = r {
                     println!("{message}");
@@ -54,7 +54,7 @@ pub enum Reason {
     NoRemote,
 }
 
-pub fn refresh_all(config: &Config) -> Result<(), Error> {
+pub fn refresh_all(config: &Config, verbosity: Verbosity) -> Result<(), Error> {
     let repos = search_mure_repo(config);
     if repos.is_empty() {
         println!("No repositories found");
@@ -70,6 +70,7 @@ pub fn refresh_all(config: &Config) -> Result<(), Error> {
                         .absolute_path
                         .to_str()
                         .expect("failed to convert to str"),
+                    verbosity,
                 );
                 match result {
                     Ok(status) => match status {
@@ -104,7 +105,7 @@ pub fn refresh_all(config: &Config) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
+pub fn refresh(repo_path: &str, verbosity: Verbosity) -> Result<RefreshStatus, Error> {
     let mut messages = vec![];
     if !PathBuf::from(repo_path).join(".git").exists() {
         return Ok(RefreshStatus::DoNothing(Reason::NotGitRepository));
@@ -130,16 +131,28 @@ pub fn refresh(repo_path: &str) -> Result<RefreshStatus, Error> {
     let result = repo.pull_fast_forwarded("origin", &default_branch);
     if let Ok(out) = result {
         match out.interpreted_to {
-            PullFastForwardStatus::AlreadyUpToDate => {
-                // messages.push(out.raw.stderr);
-                // messages.push(out.raw.stdout);
-                messages.push("Already up to date".to_string());
-            }
-            PullFastForwardStatus::FastForwarded => {
-                // messages.push(out.raw.stderr);
-                // messages.push(out.raw.stdout);
-                messages.push("Fast-forwarded".to_string());
-            }
+            PullFastForwardStatus::AlreadyUpToDate => match verbosity {
+                Verbosity::Quiet => (),
+                Verbosity::Normal => {
+                    messages.push("Already up to date".to_string());
+                }
+                Verbosity::Verbose => {
+                    messages.push("Already up to date".to_string());
+                    messages.push(out.raw.stderr);
+                    messages.push(out.raw.stdout);
+                }
+            },
+            PullFastForwardStatus::FastForwarded => match verbosity {
+                Verbosity::Quiet => (),
+                Verbosity::Normal => {
+                    messages.push("Fast-forwarded".to_string());
+                }
+                Verbosity::Verbose => {
+                    messages.push("Fast-forwarded".to_string());
+                    messages.push(out.raw.stderr);
+                    messages.push(out.raw.stdout);
+                }
+            },
             _ => (),
         };
     }
@@ -180,7 +193,7 @@ mod tests {
             .repo
             .command(&["switch", "-c", "main"])
             .unwrap();
-        let result = refresh(origin_path.to_str().unwrap());
+        let result = refresh(origin_path.to_str().unwrap(), Verbosity::Normal);
         match result {
             Ok(RefreshStatus::DoNothing(Reason::NoRemote)) => (),
             _ => unreachable!(),
@@ -203,7 +216,7 @@ mod tests {
             .unwrap();
         let path = fixture.repo.path().parent().unwrap();
 
-        let result = refresh(path.to_str().unwrap());
+        let result = refresh(path.to_str().unwrap(), Verbosity::Normal);
         match result {
             Ok(RefreshStatus::Update {
                 switch_to_default, ..
@@ -226,7 +239,7 @@ mod tests {
             .to_str()
             .expect("failed to get path");
 
-        let result = refresh(path).unwrap();
+        let result = refresh(path, Verbosity::Normal).unwrap();
         match result {
             RefreshStatus::DoNothing(Reason::NotGitRepository) => {}
             _ => unreachable!(),
@@ -238,7 +251,7 @@ mod tests {
         let fixture = Fixture::create().unwrap();
         let path = fixture.repo.path().parent().unwrap();
 
-        let result = refresh(path.to_str().unwrap()).unwrap();
+        let result = refresh(path.to_str().unwrap(), Verbosity::Normal).unwrap();
         match result {
             RefreshStatus::DoNothing(Reason::NoRemote) => {}
             _ => unreachable!(),
@@ -275,6 +288,6 @@ mod tests {
         )
         .unwrap();
 
-        refresh_all(&config).unwrap();
+        refresh_all(&config, Verbosity::Verbose).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,13 +46,8 @@ fn main() -> Result<(), mure_error::Error> {
             let verbosity = Verbosity::from_bools(quiet, verbose);
             refresh_main(&config, all, repository, verbosity)?;
         }
-        Issues {
-            query,
-            verbose,
-            quiet,
-        } => {
-            let verbosity = Verbosity::from_bools(quiet, verbose);
-            show_issues_main(&config, query, verbosity)?;
+        Issues { query } => {
+            show_issues_main(&config, query)?;
         }
         Clone {
             url,
@@ -121,14 +116,9 @@ enum Commands {
         quiet: bool,
     },
     #[command(about = "show issues")]
-    #[clap(group(ArgGroup::new("verbosity").args(&["verbose", "quiet"])))]
     Issues {
         #[arg(short = 'Q', long, help = "query to search issues")]
         query: Option<String>,
-        #[arg(short, long, help = "verbose", default_value = "false")]
-        verbose: bool,
-        #[arg(short, long, help = "quiet", default_value = "false")]
-        quiet: bool,
     },
     #[command(about = "clone repository")]
     #[clap(group(ArgGroup::new("verbosity").args(&["verbose", "quiet"])))]
@@ -410,24 +400,14 @@ cd_shims = "mucd"
 
         match Cli::parse_from(vec!["mure", "issues"]) {
             Cli {
-                command:
-                    Commands::Issues {
-                        query: None,
-                        quiet: false,
-                        verbose: false,
-                    },
+                command: Commands::Issues { query: None },
             } => (),
             _ => panic!("failed to parse"),
         }
 
         match Cli::parse_from(vec!["mure", "issues", "--query", "is:public"]) {
             Cli {
-                command:
-                    Commands::Issues {
-                        query: Some(query),
-                        quiet: false,
-                        verbose: false,
-                    },
+                command: Commands::Issues { query: Some(query) },
             } => assert_eq!(query, "is:public"),
             _ => panic!("failed to parse"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use crate::app::{issues::show_issues_main, refresh::refresh_main};
-use clap::{command, CommandFactory, Parser, Subcommand};
+use clap::{command, ArgGroup, CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Shell};
+use verbosity::Verbosity;
 use Commands::*;
 
 mod app;
@@ -10,6 +11,7 @@ mod git;
 mod github;
 mod misc;
 mod mure_error;
+mod verbosity;
 
 #[cfg(test)]
 mod test_fixture;
@@ -35,16 +37,34 @@ fn main() -> Result<(), mure_error::Error> {
         Completion { shell } => {
             generate(shell, &mut command, name, &mut std::io::stdout());
         }
-        Refresh { repository, all } => {
-            refresh_main(&config, all, repository)?;
+        Refresh {
+            repository,
+            all,
+            verbose,
+            quiet,
+        } => {
+            let verbosity = Verbosity::from_bools(quiet, verbose);
+            refresh_main(&config, all, repository, verbosity)?;
         }
-        Issues { query } => {
-            show_issues_main(&config, query)?;
+        Issues {
+            query,
+            verbose,
+            quiet,
+        } => {
+            let verbosity = Verbosity::from_bools(quiet, verbose);
+            show_issues_main(&config, query, verbosity)?;
         }
-        Clone { url } => match app::clone::clone(&config, &url) {
-            Ok(_) => (),
-            Err(e) => println!("{e}"),
-        },
+        Clone {
+            url,
+            quiet,
+            verbose,
+        } => {
+            let verbosity = Verbosity::from_bools(quiet, verbose);
+            match app::clone::clone(&config, &url, verbosity) {
+                Ok(_) => (),
+                Err(e) => println!("{e}"),
+            }
+        }
         Path { name } => match app::path::path(&config, &name) {
             Ok(_) => (),
             Err(e) => println!("{e}"),
@@ -81,6 +101,7 @@ enum Commands {
         shell: Shell,
     },
     #[command(about = "refresh repository")]
+    #[clap(group(ArgGroup::new("verbosity").args(&["verbose", "quiet"])))]
     Refresh {
         #[arg(
             index = 1,
@@ -94,16 +115,30 @@ enum Commands {
             default_value = "false"
         )]
         all: bool,
+        #[arg(short, long, help = "verbose", default_value = "false")]
+        verbose: bool,
+        #[arg(short, long, help = "quiet", default_value = "false")]
+        quiet: bool,
     },
     #[command(about = "show issues")]
+    #[clap(group(ArgGroup::new("verbosity").args(&["verbose", "quiet"])))]
     Issues {
-        #[arg(short, long, help = "query to search issues")]
+        #[arg(short = 'Q', long, help = "query to search issues")]
         query: Option<String>,
+        #[arg(short, long, help = "verbose", default_value = "false")]
+        verbose: bool,
+        #[arg(short, long, help = "quiet", default_value = "false")]
+        quiet: bool,
     },
     #[command(about = "clone repository")]
+    #[clap(group(ArgGroup::new("verbosity").args(&["verbose", "quiet"])))]
     Clone {
         #[arg(index = 1, help = "repository url")]
         url: String,
+        #[arg(short, long, help = "verbose", default_value = "false")]
+        verbose: bool,
+        #[arg(short, long, help = "quiet", default_value = "false")]
+        quiet: bool,
     },
     #[command(about = "show repository path for name")]
     Path {
@@ -340,28 +375,34 @@ cd_shims = "mucd"
                     Commands::Refresh {
                         repository: None,
                         all: false,
+                        quiet: false,
+                        verbose: false,
                     },
             } => (),
             _ => panic!("failed to parse"),
         }
 
-        match Cli::parse_from(vec!["mure", "refresh", "react"]) {
+        match Cli::parse_from(vec!["mure", "refresh", "react", "--quiet"]) {
             Cli {
                 command:
                     Commands::Refresh {
                         repository: Some(repo),
                         all: false,
+                        quiet: true,
+                        verbose: false,
                     },
             } => assert_eq!(repo, "react"),
             _ => panic!("failed to parse"),
         }
 
-        match Cli::parse_from(vec!["mure", "refresh", "--all"]) {
+        match Cli::parse_from(vec!["mure", "refresh", "--all", "--verbose"]) {
             Cli {
                 command:
                     Commands::Refresh {
                         repository: None,
                         all: true,
+                        quiet: false,
+                        verbose: true,
                     },
             } => (),
             _ => panic!("failed to parse"),
@@ -369,21 +410,36 @@ cd_shims = "mucd"
 
         match Cli::parse_from(vec!["mure", "issues"]) {
             Cli {
-                command: Commands::Issues { query: None },
+                command:
+                    Commands::Issues {
+                        query: None,
+                        quiet: false,
+                        verbose: false,
+                    },
             } => (),
             _ => panic!("failed to parse"),
         }
 
         match Cli::parse_from(vec!["mure", "issues", "--query", "is:public"]) {
             Cli {
-                command: Commands::Issues { query: Some(query) },
+                command:
+                    Commands::Issues {
+                        query: Some(query),
+                        quiet: false,
+                        verbose: false,
+                    },
             } => assert_eq!(query, "is:public"),
             _ => panic!("failed to parse"),
         }
 
         match Cli::parse_from(vec!["mure", "clone", "https://github.com/kitsuyui/mure"]) {
             Cli {
-                command: Commands::Clone { url },
+                command:
+                    Commands::Clone {
+                        url,
+                        quiet: false,
+                        verbose: false,
+                    },
             } => assert_eq!(url, "https://github.com/kitsuyui/mure"),
             _ => panic!("failed to parse"),
         }

--- a/src/verbosity.rs
+++ b/src/verbosity.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Copy)]
 pub enum Verbosity {
     Quiet,
     Normal,

--- a/src/verbosity.rs
+++ b/src/verbosity.rs
@@ -1,0 +1,15 @@
+pub enum Verbosity {
+    Quiet,
+    Normal,
+    Verbose,
+}
+
+impl Verbosity {
+    pub fn from_bools(quiet: bool, verbose: bool) -> Self {
+        match (quiet, verbose) {
+            (true, _) => Verbosity::Quiet,
+            (_, true) => Verbosity::Verbose,
+            _ => Verbosity::Normal,
+        }
+    }
+}


### PR DESCRIPTION
Close: https://github.com/kitsuyui/mure/issues/11
- Add --quiet and --verbose options
  - --quiet makes output less verbose, --verbose makes output more verbose
- --query option is renamed to -Q because it conflicts with -q option
