### PR TITLE
Use Cargo's sparse protocol

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[registries.crates-io]
+protocol = "sparse"
+
 [target.'cfg(all())']
 rustflags = [
     "-Wclippy::fallible_impl_from",


### PR DESCRIPTION
Cargo's sparse protocol was introduced in Rust 1.68.0.
By enabling this, the total amount of source code to be retrieved when installing with `cargo install` can be significantly reduced.
As a result, the speed of CI and development speed will improve.
