### PR TITLE
Customize the default query of mure issues

### DIFF
--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -6,8 +6,11 @@ use crate::mure_error::Error;
 
 pub fn show_issues_main(config: &Config, query: Option<String>) -> Result<(), Error> {
     let username = config.github.username.to_string();
-    let default_query = format!("user:{} is:public fork:false archived:false", &username);
-    let query = query.unwrap_or_else(|| default_query.to_string());
+    let default_query = config.github.get_query();
+    let query = match query {
+        Some(q) => q,
+        None => default_query,
+    };
     match show_issues(&username, &query) {
         Ok(_) => (),
         Err(e) => println!("{e}"),

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -43,6 +43,7 @@ mod tests {
             },
             github: GitHub {
                 username: "".to_string(),
+                query: None,
             },
             shell: Some(Shell {
                 cd_shims: Some("mucd".to_string()),
@@ -72,6 +73,7 @@ mod tests {
             },
             github: GitHub {
                 username: "".to_string(),
+                query: None,
             },
             shell: Some(Shell {
                 cd_shims: Some("mucd".to_string()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,20 @@ pub struct Core {
 pub struct GitHub {
     // TODO: try .gitconfig.user.name if not set
     pub username: String,
+    pub query: Option<String>,
+}
+
+impl GitHub {
+    pub fn get_query(&self) -> String {
+        let default_query = format!(
+            "user:{} is:public fork:false archived:false",
+            &self.username
+        );
+        match &self.query {
+            Some(q) => q.to_string(),
+            None => default_query,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -90,6 +104,7 @@ fn create_config(path: &Path) -> Result<Config, Error> {
         },
         github: GitHub {
             username: "".to_string(),
+            query: None,
         },
         shell: Some(Shell {
             cd_shims: Some("mucd".to_string()),


### PR DESCRIPTION
The `mure issues` command already allows you to specify a query with the `--query` option,
but you can customize the default query with mure.toml settings.
This allows you to display only issues that you own, or to change the issues displayed depending on the environment.
