### PR TITLE
Remove redundant clone (to_string())

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -95,7 +95,7 @@ impl RepositorySupport for Repository {
     ) -> Result<GitCommandOutput<PullFastForwardStatus>, Error> {
         let raw = self.command(&["pull", "--ff-only", remote, branch])?;
         let status = {
-            let message = raw.stdout.to_string();
+            let message = raw.stdout.as_str();
             if message.contains("Already up to date.") {
                 PullFastForwardStatus::AlreadyUpToDate
             } else if message.contains("Fast-forward") {


### PR DESCRIPTION
It was implemented to make a copy by to_string(), but it is actually unnecessary, so it will be removed.
It was warned by clippy.
