### PR TITLE
Enhance mure issues query

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,25 @@ Example:
 
 <img width="1023" alt="example-mure-issues" src="https://user-images.githubusercontent.com/2596972/184259022-cb428537-f12e-41b0-8b49-a72565afa167.png">
 
-### Options
+#### Options
 
 `--query` option is available for advanced search like `--query 'user:kitsuyui'`
 See this page for more about advanced search: https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories
 
 Default search query is `user:{username} is:public fork:false archived:false`
+
+#### Customization
+
+You can customize the output format by setting `github.queries` in `.mure.toml`.
+For example, if you want to show both of [my (user:kitsuyui) repositories](https://github.com/kitsuyui?tab=repositories) and the [organization gitignore-in](https://github.com/orgs/gitignore-in/repositories)'s repositories, you can set `github.queries` like this:
+
+```toml
+[github]
+queries = [
+  "user:kitsuyui",
+  "owner:gitignore-in",
+]
+```
 
 ### mure refresh
 

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -44,6 +44,7 @@ mod tests {
             github: GitHub {
                 username: "".to_string(),
                 query: None,
+                queries: None,
             },
             shell: Some(Shell {
                 cd_shims: Some("mucd".to_string()),
@@ -74,6 +75,7 @@ mod tests {
             github: GitHub {
                 username: "".to_string(),
                 query: None,
+                queries: None,
             },
             shell: Some(Shell {
                 cd_shims: Some("mucd".to_string()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,18 +29,28 @@ pub struct GitHub {
     // TODO: try .gitconfig.user.name if not set
     pub username: String,
     pub query: Option<String>,
+    pub queries: Option<Vec<String>>,
 }
 
 impl GitHub {
-    pub fn get_query(&self) -> String {
+    pub fn get_queries(&self) -> Vec<String> {
+        if let Some(qs) = &self.queries {
+            return qs.clone();
+        }
+        if let Some(q) = &self.query {
+            return vec![q.to_string()];
+        }
         let default_query = format!(
             "user:{} is:public fork:false archived:false",
             &self.username
         );
         match &self.query {
-            Some(q) => q.to_string(),
-            None => default_query,
+            Some(q) => vec![q.to_string()],
+            None => vec![default_query],
         }
+    }
+    pub fn is_both_query_and_queries_set(&self) -> bool {
+        self.query.is_some() && self.queries.is_some()
     }
 }
 
@@ -105,6 +115,7 @@ fn create_config(path: &Path) -> Result<Config, Error> {
         github: GitHub {
             username: "".to_string(),
             query: None,
+            queries: Some(vec![]),
         },
         shell: Some(Shell {
             cd_shims: Some("mucd".to_string()),

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -12,6 +12,19 @@ type URI = String;
 )]
 pub struct SearchRepositoryQuery;
 
+pub fn search_all_repositories_by_queries(
+    token: &str,
+    queries: &Vec<String>,
+) -> Result<Vec<search_repository_query::SearchRepositoryQueryReposEdgesNodeOnRepository>, Error> {
+    let mut results =
+        vec![] as Vec<search_repository_query::SearchRepositoryQueryReposEdgesNodeOnRepository>;
+    for query in queries {
+        let mut repos = search_all_repositories(token, query)?;
+        results.append(&mut repos);
+    }
+    Ok(results)
+}
+
 pub fn search_all_repositories(
     token: &str,
     query: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), mure_error::Error> {
             refresh_main(&config, all, repository, verbosity)?;
         }
         Issues { query } => {
-            show_issues_main(&config, query)?;
+            show_issues_main(&config, &query)?;
         }
         Clone {
             url,
@@ -118,8 +118,12 @@ enum Commands {
     },
     #[command(about = "show issues")]
     Issues {
+        // #[arg(short = 'Q', long, help = "query to search issues")]
+        // query: Option<String>,
+
+        // multiple arguments
         #[arg(short = 'Q', long, help = "query to search issues")]
-        query: Option<String>,
+        query: Vec<String>,
     },
     #[command(about = "clone repository")]
     #[clap(group(ArgGroup::new("verbosity").args(&["verbose", "quiet"])))]
@@ -401,15 +405,17 @@ cd_shims = "mucd"
 
         match Cli::parse_from(vec!["mure", "issues"]) {
             Cli {
-                command: Commands::Issues { query: None },
-            } => (),
+                command: Commands::Issues { query },
+            } => {
+                assert_eq!(query, vec![] as Vec<String>);
+            }
             _ => panic!("failed to parse"),
         }
 
         match Cli::parse_from(vec!["mure", "issues", "--query", "is:public"]) {
             Cli {
-                command: Commands::Issues { query: Some(query) },
-            } => assert_eq!(query, "is:public"),
+                command: Commands::Issues { query },
+            } => assert_eq!(query, vec!["is:public"]),
             _ => panic!("failed to parse"),
         }
 


### PR DESCRIPTION
The current mure issues can only set a single search condition.
On the other hand, GitHub search does not support OR condition search.
Therefore, it cannot be used to search for multiple owners.

 ### Solution

Multiple queries can be specified in the query issued by mure issues.
This allows you to search for multiple owners.
Change `github.query` set in TOML file to `github.queries` (maintain compatibility)
