### PR TITLE
Fix path resolution problem of mure refresh

### DIFF
--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -39,8 +39,11 @@ pub fn refresh_main(
 
 pub fn get_git_repository_from_current_dir(config: &Config) -> Result<PathBuf, Error> {
     let current_dir = std::env::current_dir()?;
-    let repo = Repository::discover_path(current_dir, &config.base_path())?;
-    Ok(repo)
+    let repo_git = Repository::discover_path(current_dir, &config.base_path())?;
+    if let Some(path) = repo_git.parent() {
+        return Ok(path.to_path_buf());
+    }
+    Err(Error::from_str("not a git repository"))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
There was a problem with the path resolution of `mure refresh`, and when I wanted the path of the Git repository `foobar`, the path `foobar/.git` was returned.
It was used in the internal processing, and the Git command could not be executed as intended.
Fix https://github.com/kitsuyui/mure/issues/252#issuecomment-1635090629