### PR TITLE
Fix error in repository without codecov enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codecov"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34388527da07d0df4afc705b9fecddcc6e8243cd89a15c5e467bd379c17d5c4f"
+checksum = "700a4458fa7b34d55b7fb5b6aa6ef7a2dce7390570f6a2677ca41defe342bb57"
 dependencies = [
  "reqwest",
  "serde",
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1115,9 +1115,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.7.6"
 openssl-probe = "0.1.5"
 clap_complete = "4.3.2"
 serde_json = "1.0.103"
-codecov = "0.3.1"
+codecov = "0.3.2"
 
 [dependencies.openssl]
 version = "0.10.55"

--- a/src/codecov.rs
+++ b/src/codecov.rs
@@ -36,8 +36,13 @@ pub fn get_repository_coverage(
         .collect::<HashMap<String, codecov::repos::Repo>>();
 
     for repo in repos {
-        if !codecov_all_repositories.contains_key(&repo.name) {
-            continue;
+        if let Some(repo_info) = codecov_all_repositories.get(&repo.name) {
+            if !repo_info.activated {
+                continue;
+            }
+            if !repo_info.active {
+                continue;
+            }
         }
         let author = codecov::author::Author::new("github", username, &repo.name);
         match client.get_branch_detail(&author, &repo.branch) {
@@ -49,7 +54,7 @@ pub fn get_repository_coverage(
                 });
             }
             Err(e) => {
-                println!("Failed to get coverage: {:?}", e);
+                println!("Repo {} Failed to get coverage: {:?}", repo.name, e);
             }
         }
     }


### PR DESCRIPTION
When `mure issues` is executed, an error occurs in a repository without codecov enabled.
Fix it.
It is useless to get coverage for a repository that does not have codecov enabled, so ignore such repositories.
There was a problem with the implementation of https://crates.io/crates/codecov, so I upgraded it to a version that solved it.
