### PR TITLE
Change the conditions for GitHub Workflow

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,7 +1,7 @@
 name: binary release
 
 on:
-  push:
+  pull_request:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,7 +1,6 @@
 name: Spellcheck
 on:
   - pull_request
-  - push
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: tests
 on:
   - pull_request
-  - push
 
 jobs:
   check:


### PR DESCRIPTION
- Change the one that specifies both push and pull_request to pull_request only.
  - I initially misunderstood that pull_request only works when opened. It also works with update, so pull_request only for those that specify both push and pull_request.
- Add pull_request to those that are missing.
  - The binary-release Workflow was missing pull_request, so I add it.
