### PR TITLE
Use codecov-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codecov-cache"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eb2662d1b9455ad0457d479d9271a18338ece596fb5762ed21dd1e62b64cf7"
+dependencies = [
+ "codecov",
+ "dirs",
+ "serde_json",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +882,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "codecov",
+ "codecov-cache",
+ "dirs",
  "git2",
  "graphql_client",
  "mktemp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ openssl-probe = "0.1.5"
 clap_complete = "4.3.2"
 serde_json = "1.0.105"
 codecov = "0.3.3"
+codecov-cache = "0.1.0"
+dirs = "5.0.1"
 
 [dependencies.openssl]
 version = "0.10.56"

--- a/graphql/schema/query.graphql
+++ b/graphql/schema/query.graphql
@@ -16,8 +16,13 @@ query SearchRepositoryQuery($query: String!, $cursor: String, $first: Int!) {
         ... on Repository {
           url
           name
+          __typename
           defaultBranchRef {
             name
+            target {
+              __typename
+              oid
+            }
           }
           latestRelease {
             name

--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -97,6 +97,14 @@ impl RepoBranch {
                 .as_ref()
                 .map(|default_branch_ref| default_branch_ref.name.clone())
                 .unwrap_or_default(),
+            commit_id: repo
+                .default_branch_ref
+                .as_ref()
+                .map(|default_branch_ref| match &default_branch_ref.target {
+                    Some(target) => target.oid.clone(),
+                    None => "".to_string(),
+                })
+                .unwrap_or_default(),
         }
     }
 }

--- a/src/codecov.rs
+++ b/src/codecov.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::mure_error;
 
@@ -11,6 +11,7 @@ pub struct Coverage {
 pub struct RepoBranch {
     pub(crate) name: String,
     pub(crate) branch: String,
+    pub(crate) commit_id: String,
 }
 
 fn get_codecov_token() -> Result<String, mure_error::Error> {
@@ -27,7 +28,12 @@ pub fn get_repository_coverage(
     repos: &Vec<RepoBranch>,
 ) -> Result<Vec<Coverage>, mure_error::Error> {
     let token = get_codecov_token()?;
-    let client = codecov::Client::new(token);
+    let cache_dir = dirs::cache_dir()
+        .ok_or_else(|| mure_error::Error::from_str("Failed to get cache dir"))?
+        .join("mure")
+        .join("codecov");
+
+    let client = codecov_cache::Client::new(token, PathBuf::from(&cache_dir));
     let codecov_repos = client.get_all_repos(&codecov::owner::Owner::new("github", username))?;
     let mut repo_coverage = Vec::new();
     let codecov_all_repositories = codecov_repos
@@ -45,7 +51,7 @@ pub fn get_repository_coverage(
             }
         }
         let author = codecov::author::Author::new("github", username, &repo.name);
-        match client.get_branch_detail(&author, &repo.branch) {
+        match client.get_branch_detail_with_commit_id(&author, &repo.branch, &repo.commit_id) {
             Ok(branch_detail) => {
                 let coverage = branch_detail.latest_coverage();
                 repo_coverage.push(Coverage {
@@ -70,6 +76,7 @@ mod tests {
         let repos = vec![RepoBranch {
             name: "mure".to_string(),
             branch: "main".to_string(),
+            commit_id: "1234567890abcdef".to_string(),
         }];
         let repo_coverage = get_repository_coverage("kitsuyui", &repos).unwrap();
         assert!(!repo_coverage.is_empty());

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -7,6 +7,9 @@ type URI = String;
 #[allow(clippy::upper_case_acronyms)]
 type DateTime = String;
 
+#[allow(clippy::upper_case_acronyms)]
+type GitObjectID = String;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "graphql/schema/schema.docs.graphql",

--- a/src/mure_error.rs
+++ b/src/mure_error.rs
@@ -53,3 +53,9 @@ impl From<codecov::errors::Error> for Error {
         Error::CodecovError(format!("{:?}", e))
     }
 }
+
+impl From<codecov_cache::errors::Error> for Error {
+    fn from(e: codecov_cache::errors::Error) -> Error {
+        Error::CodecovError(format!("{:?}", e))
+    }
+}


### PR DESCRIPTION
Use https://crates.io/crates/codecov-cache .
This will greatly reduce the time it takes to run mure issues.
In my case, it took about 25 seconds to run, but now it takes about 15 seconds.
