### PR TITLE
Workaround: Lint error

### DIFF
--- a/src/mure_error.rs
+++ b/src/mure_error.rs
@@ -2,6 +2,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub enum Error {
     Message(String),


### PR DESCRIPTION
- with #[allow(clippy::enum_variant_names)]
- This enum variant name is bad. I must fix it later.
