### PR TITLE
Fix: lint warning in git.rs

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -155,7 +155,6 @@ impl From<FromUtf8Error> for mure_error::Error {
 
 fn split_lines(lines: &str) -> Vec<String> {
     lines
-        .to_string()
         .split('\n')
         .map(|s| s.to_string())
         .filter(|s| !s.is_empty())


### PR DESCRIPTION
- Remove unused conversion
