### PR TITLE
workaround: build erorr in Ubuntu 24.04

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -31,6 +31,7 @@ jobs:
             package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
           - arch: aarch64-unknown-linux-musl
+            # https://github.com/kitsuyui/mure/issues/615
             os: ubuntu-22.04
             package: gcc-aarch64-linux-gnu musl-tools
             gcc: aarch64-linux-gnu-gcc
@@ -40,6 +41,7 @@ jobs:
             package: gcc-arm-linux-gnueabihf
             gcc: arm-linux-gnueabihf-gcc
           - arch: armv7-unknown-linux-musleabihf
+            # https://github.com/kitsuyui/mure/issues/615
             os: ubuntu-22.04
             package: gcc-arm-linux-gnueabihf musl-tools
             gcc: arm-linux-gnueabihf-gcc

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -31,7 +31,7 @@ jobs:
             package: gcc-aarch64-linux-gnu
             gcc: aarch64-linux-gnu-gcc
           - arch: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-22.04
             package: gcc-aarch64-linux-gnu musl-tools
             gcc: aarch64-linux-gnu-gcc
             cflags: -U_FORTIFY_SOURCE
@@ -40,7 +40,7 @@ jobs:
             package: gcc-arm-linux-gnueabihf
             gcc: arm-linux-gnueabihf-gcc
           - arch: armv7-unknown-linux-musleabihf
-            os: ubuntu-latest
+            os: ubuntu-22.04
             package: gcc-arm-linux-gnueabihf musl-tools
             gcc: arm-linux-gnueabihf-gcc
             cflags: -U_FORTIFY_SOURCE


### PR DESCRIPTION
- Same as https://github.com/kitsuyui/rust-playground/issues/367

The error message is:

```
`__isoc23_strtol'
          collect2: error: ld returned 1 exit status
```
