### PR TITLE
Propagate subcommand errors to the CLI exit status

### DIFF
--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -16,11 +16,7 @@ pub fn show_issues_main(config: &Config, queries: &[String]) -> Result<(), Error
     } else {
         queries.to_vec()
     };
-    match show_issues(&queries) {
-        Ok(_) => (),
-        Err(e) => println!("{e}"),
-    }
-    Ok(())
+    show_issues(&queries)
 }
 
 pub struct RepositorySummary {
@@ -115,27 +111,19 @@ pub fn show_issues(queries: &Vec<String>) -> Result<(), Error> {
     let Ok(token) = github::token::get_github_token() else {
         return Err(Error::from_str("GH_TOKEN is not set"));
     };
-    match github::api::search_all_repositories_by_queries(&token, queries) {
-        Err(e) => println!("{e}"),
-        Ok(result) => {
-            match repository_summary(&result) {
-                Ok(results) => {
-                    // header
-                    println!("Issues\tPRs\tBranch\tLastRelease\tURL");
-                    for result in results {
-                        println!(
-                            "{}\t{}\t{}\t{}\t{}",
-                            result.github.number_of_issues,
-                            result.github.number_of_pull_requests,
-                            result.default_branch(),
-                            result.github.last_release_at,
-                            result.github.url,
-                        );
-                    }
-                }
-                Err(e) => println!("{e}"),
-            }
-        }
-    };
+    let result = github::api::search_all_repositories_by_queries(&token, queries)?;
+    let results = repository_summary(&result)?;
+    // header
+    println!("Issues\tPRs\tBranch\tLastRelease\tURL");
+    for result in results {
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            result.github.number_of_issues,
+            result.github.number_of_pull_requests,
+            result.default_branch(),
+            result.github.last_release_at,
+            result.github.url,
+        );
+    }
     Ok(())
 }

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -10,6 +10,7 @@ pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
         println!("No repositories found");
         return Ok(());
     }
+    let mut first_error = None;
     for repo in repos {
         match repo {
             Ok(mure_repo) => {
@@ -35,10 +36,16 @@ pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
             }
             Err(e) => {
                 println!("{}", e.message());
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
             }
         }
     }
-    Ok(())
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 pub struct MureRepo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,23 +69,17 @@ fn main() -> Result<(), mure_error::Error> {
             verbose,
         } => {
             let verbosity = Verbosity::from_bools(quiet, verbose);
-            match app::clone::clone(&config, &url, verbosity) {
-                Ok(_) => (),
-                Err(e) => println!("{e}"),
-            }
+            app::clone::clone(&config, &url, verbosity)?;
         }
-        Path { name } => match app::path::path(&config, &name) {
-            Ok(_) => (),
-            Err(e) => println!("{e}"),
-        },
-        List { path, full } => match app::list::list(&config, path, full) {
-            Ok(_) => (),
-            Err(e) => println!("{e}"),
-        },
-        Edit { name } => match app::edit::edit(&config, name) {
-            Ok(_) => (),
-            Err(e) => println!("{e}"),
-        },
+        Path { name } => {
+            app::path::path(&config, &name)?;
+        }
+        List { path, full } => {
+            app::list::list(&config, path, full)?;
+        }
+        Edit { name } => {
+            app::edit::edit(&config, name)?;
+        }
     }
     Ok(())
 }
@@ -359,6 +353,36 @@ cd_shims = "mucd"
             .args(vec!["run", "--", "refresh", "--all"])
             .assert();
         assert.success();
+        drop(temp_dir);
+        drop(base_dir);
+    }
+
+    #[test]
+    fn test_path_error_exits_with_failure() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+        let mure_config_path = temp_dir.as_path().join(".mure.toml");
+        let base_dir = Temp::new_dir().expect("failed to create temp dir");
+        let content = format!(
+            r#"
+[core]
+base_dir = "{}"
+
+[github]
+username = "kitsuyui"
+
+[shell]
+cd_shims = "mucd"
+"#,
+            base_dir.as_path().to_str().unwrap()
+        );
+        std::fs::write(&mure_config_path, content).unwrap();
+        let assert = Command::new("cargo")
+            .env("MURE_CONFIG_PATH", mure_config_path)
+            .args(vec!["run", "--", "path", "missing"])
+            .assert();
+        assert
+            .failure()
+            .stderr(predicate::str::contains("missing is not a git repository"));
         drop(temp_dir);
         drop(base_dir);
     }


### PR DESCRIPTION
## Summary

Propagate subcommand failures to the process exit status so scripts and CI can detect failed operations.

## Details

- Return errors from `clone`, `path`, `list`, and `edit` command branches instead of printing and continuing with exit 0.
- Return errors from the `issues` flow instead of swallowing GitHub API and summarization failures.
- Make `list` return a failure when repository discovery produced any invalid entry.
- Add a regression test that verifies a failed `path` lookup exits non-zero.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`
