### PR TITLE
Add actionlint check for workflows

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -16,7 +16,6 @@ jobs:
       OS: ${{ matrix.os }}
       PACKAGE: ${{ matrix.package }}
       GCC: ${{ matrix.gcc }}
-      CFLAGS: ${{ matrix.cflags }}
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +53,7 @@ jobs:
           if [[ $OS =~ ^.*ubuntu.*$ ]]; then
             rustup target add $ARCH
             sudo apt-get update && sudo apt-get install -y $PACKAGE
-            TARGET="$ARCH" CFLAGS="$CFLAGS" CC=$GCC cargo build --release --verbose --target $ARCH
+            TARGET="$ARCH" CC=$GCC cargo build --release --verbose --target $ARCH
           elif [[ $OS =~ ^.*macos.*$ ]]; then
             cargo build --release --verbose --target $ARCH
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/*.yml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Remove the undefined `matrix.cflags` reference from the binary release workflow
- Add an Actionlint check for GitHub Actions workflow syntax and expressions

## Verification

- `actionlint -shellcheck= .github/workflows/*.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/*.yml`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check`

Note: shellcheck info-level workflow findings are intentionally left out of this baseline by running Actionlint with `-shellcheck=`.
