### PR TITLE
Use reusable actionlint and gh-counter workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,9 @@ jobs:
       - run: cargo fmt --all -- --check
 
   actionlint:
-    name: Actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-      - run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/*.yml
-
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
+    with:
+      shellcheck: disabled
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace local actionlint and/or gh-counter job definitions with reusable workflow callers from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific workflow triggers and permissions unchanged.

## Changed files
- `.github/workflows/test.yml`

## Validation
- `actionlint -color=false <updated workflow files>`
- `git diff --check`
