### PR TITLE
Pin happy workflow ref

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary
- Pin the reusable happy-commit workflow to a full commit SHA instead of the moving `main` ref.

## Verification
- `git diff --check`
- `actionlint .github/workflows/happy.yml`
- Verified the pinned workflow file is resolvable through the GitHub API.