### PR TITLE
Restrict test workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
## Summary
- Add explicit read-only `contents` permission to the test workflow.

## Verification
- `git diff --check`
- `actionlint .github/workflows/test.yml`