### PR TITLE
Remove unreachable match in GitHub::get_queries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,14 +41,10 @@ impl GitHub {
         if let Some(q) = &self.query {
             return vec![q.to_string()];
         }
-        let default_query = format!(
+        vec![format!(
             "user:{} is:public fork:false archived:false",
             &self.username
-        );
-        match &self.query {
-            Some(q) => vec![q.to_string()],
-            None => vec![default_query],
-        }
+        )]
     }
     pub fn is_both_query_and_queries_set(&self) -> bool {
         self.query.is_some() && self.queries.is_some()


### PR DESCRIPTION
## Summary

`GitHub::get_queries` in `src/config.rs` had a final `match &self.query` block that was unreachable: when execution reaches it, the function has already early-returned for both `Some` (line 41-43) and we are guaranteed to be in the `None` case. Replace the dead `match` with a direct construction of the default-query vector.

## Why

- The unreachable `Some(q) => vec![q.to_string()]` arm duplicated the early-return path and could mislead a future reader into believing both arms are live.
- Removing the dead branch keeps `get_queries` honest about its contract: when neither `queries` nor `query` is set, return the default query.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo check`
- `cargo test` (45 passed; 0 failed)

## Test plan

- [ ] CI on this PR is green.