### PR TITLE
Remove dead duplicate loop in repository_summary

### DIFF
--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -85,11 +85,6 @@ impl GitHubRepoSummary {
 pub fn repository_summary(
     repos: &Vec<SearchRepositoryQueryReposEdgesNodeOnRepository>,
 ) -> Result<Vec<RepositorySummary>, Error> {
-    let mut results: Vec<GitHubRepoSummary> = Vec::new();
-    for repo in repos {
-        results.push(GitHubRepoSummary::new_from_api(repo));
-    }
-
     let mut results: Vec<RepositorySummary> = Vec::new();
     for repo in repos {
         let gh_summary = GitHubRepoSummary::new_from_api(repo);


### PR DESCRIPTION
## Summary

`repository_summary()` declared `let mut results: Vec<GitHubRepoSummary>` and ran a loop populating it, then immediately re-declared `let mut results: Vec<RepositorySummary>` with the same name. Rust's variable shadowing silently discarded the first vector, so `GitHubRepoSummary::new_from_api(repo)` was called twice per repository — once for the discarded vector, then again inside the second loop.

This change removes the first dead loop so each repository's API summary is constructed once.

Behavior is unchanged for callers: only the second loop's `Vec<RepositorySummary>` was ever returned. The fix avoids the redundant per-repository allocation and call.

## Test plan

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test` (45 passed)