### PR TITLE
Avoid panic when latest_release.published_at is shorter than 10 bytes

### DIFF
--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -71,13 +71,10 @@ impl GitHubRepoSummary {
             last_release_at: repo
                 .latest_release
                 .as_ref()
-                .map(|release| {
-                    if let Some(content) = release.published_at.as_ref() {
-                        return content[..10].to_string();
-                    }
-                    "****-**-**".to_string()
-                })
-                .unwrap_or("****-**-**".to_string()),
+                .and_then(|release| release.published_at.as_ref())
+                .and_then(|content| content.get(..10))
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "****-**-**".to_string()),
         }
     }
 }


### PR DESCRIPTION
## Summary

`GitHubRepoSummary::new_from_api` previously sliced `content[..10]` directly to extract the `YYYY-MM-DD` prefix from `latest_release.published_at`. If GitHub returned a value shorter than 10 bytes (or one whose first 10 bytes did not fall on a UTF-8 character boundary), the slice would panic and abort the entire `mure issues` run.

This change rewrites the chain to `.and_then(|c| c.get(..10))`. `str::get(..10)` returns `None` for both short strings and non-boundary slices, so unexpected values gracefully fall back to the existing placeholder `****-**-**` — the same fallback used when `latest_release` or `published_at` is missing.

## Test plan

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test` (45 passed)