### PR TITLE
Preserve symlink error context in clone

### DIFF
--- a/src/app/clone.rs
+++ b/src/app/clone.rs
@@ -35,7 +35,7 @@ pub fn clone(config: &Config, repo_url: &str, verbosity: Verbosity) -> Result<()
     let link_to = config.repo_work_path(&repo_info.domain, &repo_info.owner, &repo_info.repo);
     match unix_fs::symlink(tobe_clone, link_to) {
         Ok(_) => Ok(()),
-        Err(_) => Err(Error::from_str("failed to create symlink")),
+        Err(e) => Err(Error::from_str(&format!("failed to create symlink: {e}"))),
     }
 }
 


### PR DESCRIPTION
## Summary

When `clone` failed to create a symlink, the previous code dropped the `io::Error` via `Err(_)` and always returned the bare string `failed to create symlink`. The reason for the failure (permission denied, an existing file, a missing target, etc.) was lost, making it hard for users to tell what went wrong.

## Change

In `src/app/clone.rs:36-39`, replace `Err(_)` with `Err(e)` and include the `io::Error` `Display` in the message as `failed to create symlink: {e}`. Because the error type is string-message based, this is the minimal change needed to preserve the underlying context.

## Test plan
- [x] `cargo check`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (45 cases, all green)