### PR TITLE
Trim trailing whitespace from gh repo view output

### DIFF
--- a/src/gh.rs
+++ b/src/gh.rs
@@ -28,7 +28,7 @@ pub fn get_default_branch(workdir: &PathBuf) -> Result<String, Error> {
     let Ok(message) = String::from_utf8(result.stdout) else {
         return Err(Error::from_str("failed to get default branch"));
     };
-    Ok(message)
+    Ok(message.trim().to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`get_default_branch` returned the raw stdout from `gh repo view -t '{{.defaultBranchRef.name}}'` in `src/gh.rs:28-31`. Depending on the `gh` version or template, that stdout can include a trailing newline. The returned value is then passed straight to `git switch` and `git pull --ff-only` via libgit2 (`src/app/refresh.rs:126-138`), where any trailing whitespace makes the branch name unmatched and fails the operation silently.

This change calls `.trim()` on the captured stdout before returning so the branch name is robust against `gh` output variations.

## What changed

- `src/gh.rs`: `Ok(message)` → `Ok(message.trim().to_string())` for the success path of `get_default_branch`.

## Verification

Local on this branch:

- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo check`: clean
- `cargo test`: 45 tests, all passing (including the existing `gh::tests::test_get_default_branch` which asserts `== "main"`).

## Notes

- Behavior is unchanged when `gh` already produces a trimmed value (the current case in this repo's CI environment); `.trim()` is a no-op there.
- The error path that wraps `result.stderr` is left unchanged; that path is already exclusively for surfacing `gh` error messages and is out of scope here.