### PR TITLE
Pin workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -76,7 +76,7 @@ jobs:
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Archive artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: result
           path: |
@@ -88,13 +88,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: result
           path: ./artifacts
       - name: List
         run: find ./artifacts
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: ./artifacts/*.tar.gz

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   actionlint:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main
     with:
       shellcheck: disabled
   lint:


### PR DESCRIPTION
## Summary

Pin the five external `uses:` references flagged by the supply-chain audit to 40-character commit SHAs:

| File | Before | After |
| --- | --- | --- |
| `binary-release.yml:79` | `actions/upload-artifact@v6` | `actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6` |
| `binary-release.yml:91` | `actions/download-artifact@v7` | `actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7` |
| `binary-release.yml:98` | `softprops/action-gh-release@v2` | `softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |
| `test.yml:47` | `kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

Each pinned SHA is the resolved tip of the existing tag, so behavior is unchanged. Remaining unpinned `uses:` (`actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`) are out of scope for this finding's evidence and will be tracked separately if re-audited.

Renovate already extends `helpers:pinGitHubActionDigests` via `local>kitsuyui/renovate-config`, so future digest updates continue through automated PRs.

## Test plan

- [x] `git diff` confirms only the five `uses:` lines change
- [x] Each SHA verified as the v6/v7/v2/main tip via `gh api repos/.../git/refs/tags/...`