### PR TITLE
fix: correct unreachable early-exit condition in retry loop

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -160,7 +160,7 @@ fn github_api_request_with_retry<T: serde::Serialize, S: serde::de::DeserializeO
                 return Err(Error::from_str(&res.text()?));
             }
             Err(err) => {
-                if retries >= max_retries {
+                if retries + 1 >= max_retries {
                     return Err(Error::from(err));
                 }
             }


### PR DESCRIPTION
## Summary

`github_api_request_with_retry` loops with `for retries in 0..max_retries`,
so `retries` reaches at most `max_retries - 1` inside the loop body.  The
network-error branch checked `if retries >= max_retries`, a condition that
can never be true.  As a result:

- Every network error (timeout, connection reset) fell through to
  `thread::sleep(backoff)` — including on the final attempt.
- After all retries were exhausted, the loop fell through to
  `Err(Error::from_str("Failed to request to github api"))`, discarding
  the original `reqwest::Error` and its diagnostic message.

## Change

Change the guard to `retries + 1 >= max_retries` so the last retry
propagates the original error, making network failures diagnosable.

## Verification

`cargo clippy -- -D warnings` reports no issues.
`cargo test` shows the same 1 pre-existing failure
(`gh::tests::test_get_default_branch`, which requires a live `gh` auth
context not available in this local environment) and 44 passing tests.

## Trade-offs

The behaviour change is limited to the final retry iteration for
network errors: the function now returns the `reqwest::Error` directly
instead of the generic string.  The number of retries and the sleep
schedule are unchanged.