### PR TITLE
fix: send CLI errors to stderr

### DIFF
--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -31,7 +31,7 @@ pub fn refresh_main(
                     println!("{message}");
                 }
             }
-            Err(e) => println!("{e}"),
+            Err(e) => eprintln!("{e}"),
         }
     }
     Ok(())
@@ -100,12 +100,12 @@ pub fn refresh_all(config: &Config, verbosity: Verbosity) -> Result<(), Error> {
                         }
                     },
                     Err(e) => {
-                        println!("{}", e.message());
+                        eprintln!("{}", e.message());
                     }
                 }
             }
             Err(e) => {
-                println!("{}", e.message());
+                eprintln!("{}", e.message());
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), mure_error::Error> {
                 println!("Initialized config file");
             }
             Err(e) => {
-                println!("{e}");
+                eprintln!("{e}");
             }
         },
         Completion { shell, cd: true } => {
@@ -322,10 +322,10 @@ mod tests {
             .env("MURE_CONFIG_PATH", mure_config_path)
             .args(vec!["run", "--", "init"])
             .assert();
-        assert.success().stdout(
-            predicate::str::contains("Initialized config file")
-                .or(predicate::str::contains("config file already exists")),
-        );
+        assert
+            .success()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains("config file already exists"));
         drop(temp_dir);
     }
 


### PR DESCRIPTION
## Summary

- Route CLI error messages from `init` and refresh failure paths to stderr.
- Keep normal status and success output on stdout.
- Add a CLI assertion that an `init` configuration conflict reports through stderr with empty stdout.

## Tests

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check`
