### PR TITLE
fix: sort search_mure_repo output by relative path for deterministic order

### DIFF
--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -78,6 +78,12 @@ pub fn search_mure_repo(config: &Config) -> Vec<Result<MureRepo, Error>> {
             repos.push(Err(Error::from_str("failed to read dir")));
         }
     }
+    repos.sort_by(|a, b| match (a, b) {
+        (Ok(a), Ok(b)) => a.relative_path.cmp(&b.relative_path),
+        (Ok(_), Err(_)) => std::cmp::Ordering::Less,
+        (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
+        (Err(_), Err(_)) => std::cmp::Ordering::Equal,
+    });
     repos
 }
 


### PR DESCRIPTION
## Summary

`search_mure_repo()` returned repositories in filesystem `read_dir()` order, which is unspecified by POSIX and varies across OS, filesystem, and directory entry count. This caused `mure list` output to be non-deterministic, while the shell completion (`mucd_target_completer`) was already sorting the same results — an inconsistency that could confuse scripts or snapshot tests relying on list output.

## Change

Sort `search_mure_repo()` results by `relative_path` before returning, so all callers get a stable, lexicographic order. `Ok` entries are sorted alphabetically; `Err` entries are grouped after all successful entries.

- `src/app/list.rs`: add `sort_by` at the end of `search_mure_repo()`

## Verification

- `cargo clippy -- -D warnings`: clean
- `cargo fmt`: no changes
- `cargo test`: 44 passed, 1 pre-existing failure (`gh::tests::test_get_default_branch` — GitHub auth not configured in submodule environment, unrelated to this change)

## Trade-offs

The sort is O(n log n) over the number of managed repos. For the typical mure workload (tens to low hundreds of repos) this is negligible. The change is purely additive — no public API is altered.
