### PR TITLE
fix: fold conflict check into get_queries() and return Result

### DIFF
--- a/src/app/issues.rs
+++ b/src/app/issues.rs
@@ -7,12 +7,7 @@ use crate::mure_error::Error;
 
 pub fn show_issues_main(config: &Config, queries: &[String]) -> Result<(), Error> {
     let queries = if queries.is_empty() {
-        if config.github.is_both_query_and_queries_set() {
-            return Err(Error::from_str(
-                "Both query and queries are set. Please set only one of them.",
-            ));
-        }
-        config.github.get_queries()
+        config.github.get_queries()?
     } else {
         queries.to_vec()
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,20 +34,22 @@ pub struct GitHub {
 }
 
 impl GitHub {
-    pub fn get_queries(&self) -> Vec<String> {
+    pub fn get_queries(&self) -> Result<Vec<String>, Error> {
+        if self.query.is_some() && self.queries.is_some() {
+            return Err(Error::from_str(
+                "Both query and queries are set. Please set only one of them.",
+            ));
+        }
         if let Some(qs) = &self.queries {
-            return qs.clone();
+            return Ok(qs.clone());
         }
         if let Some(q) = &self.query {
-            return vec![q.to_string()];
+            return Ok(vec![q.to_string()]);
         }
-        vec![format!(
+        Ok(vec![format!(
             "user:{} is:public fork:false archived:false",
             &self.username
-        )]
-    }
-    pub fn is_both_query_and_queries_set(&self) -> bool {
-        self.query.is_some() && self.queries.is_some()
+        )])
     }
 }
 


### PR DESCRIPTION
## Summary

The `GitHub` config struct has two fields for specifying search queries —
`query: Option<String>` and `queries: Option<Vec<String>>` — but the
precedence rule (`queries` wins over `query`) was only enforced at a single
call site in `show_issues_main`. Any future caller of `get_queries()` would
silently apply the `queries`-wins rule without seeing an error when both
fields are set.

## Changes

- `get_queries()` now returns `Result<Vec<String>, Error>` and validates that
  `query` and `queries` are not both set before returning.
- `is_both_query_and_queries_set()` is removed; its logic is now internal to
  `get_queries()`.
- `show_issues_main` is simplified to `config.github.get_queries()?`.

## Behavior

No behavior change for existing users: the same error message is produced when
both fields are set. The fix ensures this check cannot be bypassed by calling
`get_queries()` directly.

## Verification

- `cargo fmt` — no changes
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 45 passed, 0 failed
