### PR TITLE
fix: send clone diagnostic and list error output to stderr

### DIFF
--- a/src/app/clone.rs
+++ b/src/app/clone.rs
@@ -24,10 +24,10 @@ pub fn clone(config: &Config, repo_url: &str, verbosity: Verbosity) -> Result<()
     match verbosity {
         Verbosity::Quiet => (),
         Verbosity::Normal => {
-            println!("{}", result.raw.stderr);
+            eprintln!("{}", result.raw.stderr);
         }
         Verbosity::Verbose => {
-            println!("{}", result.raw.stderr);
+            eprintln!("{}", result.raw.stderr);
             println!("{}", result.raw.stdout);
         }
     }

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -35,7 +35,7 @@ pub fn list(config: &Config, path: bool, full: bool) -> Result<(), Error> {
                 }
             }
             Err(e) => {
-                println!("{}", e.message());
+                eprintln!("{}", e.message());
                 if first_error.is_none() {
                     first_error = Some(e);
                 }


### PR DESCRIPTION
## Summary

Two locations were routing diagnostic or error output to stdout instead of stderr:

- `app/clone.rs`: git clone's stderr (progress, remote messages) was forwarded
  via `println!`, mixing diagnostic strings into stdout when the output is piped.
- `app/list.rs`: repository load errors were printed via `println!`, mixing error
  messages into `mure list` stdout output.

## Changes

- `src/app/clone.rs`: replace `println!("{}", result.raw.stderr)` with
  `eprintln!` in both `Verbosity::Normal` and `Verbosity::Verbose` branches.
- `src/app/list.rs`: replace `println!("{}", e.message())` with `eprintln!`.

## Behavior

No change for interactive use. For piped use:

- `mure clone <url> | cmd` — git diagnostic strings no longer reach `cmd`.
- `mure list | xargs cmd` — error messages no longer appear as repo names.

## Verification

- `cargo fmt` — no changes
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 45 passed, 0 failed
