### PR TITLE
fix: surface original error when config file exists but is unreadable

### DIFF
--- a/src/app/initialize.rs
+++ b/src/app/initialize.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, get_config, initialize_config};
+use crate::config::{Config, get_config, initialize_config, resolve_config_path};
 use crate::mure_error::Error;
 
 pub fn init() -> Result<Config, Error> {
@@ -9,12 +9,16 @@ pub fn init() -> Result<Config, Error> {
 pub fn get_config_or_initialize() -> Result<Config, Error> {
     match get_config() {
         Ok(config) => Ok(config),
-        Err(_) => match init() {
-            // if not found, create config
-            // TODO: with dialog
-            // TODO: care other error cases
-            Ok(config) => Ok(config),
-            Err(e) => Err(e),
-        },
+        Err(get_err) => {
+            // Only auto-initialize when the config file is absent.
+            // If the file exists but is unreadable or contains invalid TOML,
+            // surface the original error instead of masking it with
+            // "config file already exists".
+            let config_exists = resolve_config_path().map(|p| p.exists()).unwrap_or(false);
+            if config_exists {
+                return Err(get_err);
+            }
+            init()
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ fn create_config(path: &Path) -> Result<Config, Error> {
 /// resolve config path
 ///
 /// Resolve mure configuration path. Usually this is $HOME/.mure.toml
-fn resolve_config_path() -> Result<PathBuf, Error> {
+pub(crate) fn resolve_config_path() -> Result<PathBuf, Error> {
     // TODO: Is $HOME/.murerc better?
     // Or should try ~/.config/mure.toml?
 


### PR DESCRIPTION
## Summary

`get_config_or_initialize()` was catching all errors from `get_config()`
and falling back to `init()` regardless of the error kind. When the config
file exists but contains invalid TOML (or has a permission problem),
`init()` returns `"config file already exists"`, completely hiding the
original error.

## Changes

- `src/config.rs`: expose `resolve_config_path()` as `pub(crate)`.
- `src/app/initialize.rs`: after a `get_config()` failure, check whether
  the config file is actually present. If it is, return the original error
  instead of attempting `init()`. If the file is absent, proceed to
  `init()` as before.

## Behavior

- Config file absent (first run): unchanged — `init()` is called and a
  default config is created.
- Config file present but unparseable (e.g., broken TOML): now returns the
  original parse error rather than `"config file already exists"`.
- Config file present and readable: unchanged — returns `Ok(config)`.

## Verification

- `cargo fmt` — no changes
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 45 passed, 0 failed