### PR TITLE
Use owner-qualified work paths for cloned repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ This application requires the following environment variable.
 $HOME/.mure.toml ... configuration file
 $HOME/.dev ... development directory
 $HOME/.dev/repo ... repositories directory
+$HOME/.dev/github.com/{owner}/{repo} ... working repository symlink
 ```
 
-When you clone a repository, it will be clone into the `$HOME/.dev/repo/github.com/{owner}/{repo}` directory.
+When you clone a repository, it will be cloned into the `$HOME/.dev/repo/github.com/{owner}/{repo}` directory.
+It also creates a symlink at `$HOME/.dev/github.com/{owner}/{repo}` for daily work.
 
 ## requirements
 
@@ -105,7 +107,7 @@ queries = [
 mucd enables you to change directory into the repository.
 
 ```shell
-mucd something  # => Same as `cd $HOME/.dev/something`
+mucd something  # => Same as `cd "$(mure path something)"`
 ```
 
 You can change the name of the shim by set `shell.cd_shims` in `.mure.toml` to another name.

--- a/src/app/clone.rs
+++ b/src/app/clone.rs
@@ -33,6 +33,10 @@ pub fn clone(config: &Config, repo_url: &str, verbosity: Verbosity) -> Result<()
     }
 
     let link_to = config.repo_work_path(&repo_info.domain, &repo_info.owner, &repo_info.repo);
+    let Some(link_parent) = link_to.parent() else {
+        return Err(Error::from_str("invalid repo url (maybe root dir)"));
+    };
+    std_fs::create_dir_all(link_parent)?;
     match unix_fs::symlink(tobe_clone, link_to) {
         Ok(_) => Ok(()),
         Err(e) => Err(Error::from_str(&format!("failed to create symlink: {e}"))),
@@ -70,6 +74,11 @@ mod tests {
             Ok(_) => {}
             Err(_) => unreachable!(),
         }
+        assert!(
+            config
+                .repo_work_path("github.com", "kitsuyui", "mure")
+                .is_symlink()
+        );
         let config: Config = toml::from_str(&config_file).unwrap();
 
         let Err(error) = clone(&config, "", Verbosity::Normal) else {

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -3,12 +3,11 @@ use std::path::PathBuf;
 
 use git2::Repository;
 
-use crate::config::{Config, ConfigSupport};
+use crate::config::Config;
 use crate::mure_error::Error;
 
 pub fn edit(config: &Config, repository: String) -> Result<(), Error> {
-    let mure_root_dir = config.base_path();
-    let path = mure_root_dir.join(repository);
+    let path = crate::app::path::resolve(config, &repository)?;
     let editor = get_editor(config, &path)?;
     open_editor(&editor, &path)?;
     Ok(())

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::{Config, ConfigSupport};
 use crate::github::repo::RepoInfo;
@@ -56,29 +56,62 @@ pub struct MureRepo {
 
 pub fn search_mure_repo(config: &Config) -> Vec<Result<MureRepo, Error>> {
     let mut repos = vec![];
-    match config.base_path().read_dir() {
-        Ok(dir) => {
-            dir.for_each(|entry| {
-                if let Ok(entry) = entry {
-                    let metadata = match std::fs::symlink_metadata(entry.path()) {
-                        Ok(metadata) => metadata,
-                        Err(_) => return,
-                    };
-                    if !metadata.is_symlink() {
-                        return;
-                    }
-                    match read_symlink_as_mure_repo(&entry.path()) {
-                        Ok(mure_repo) => repos.push(Ok(mure_repo)),
-                        Err(e) => repos.push(Err(e)),
-                    }
-                }
-            });
-        }
-        Err(_) => {
-            repos.push(Err(Error::from_str("failed to read dir")));
-        }
+    collect_mure_repos(&config.base_path(), &config.repos_store_path(), &mut repos);
+    if repos.is_empty() && !config.base_path().is_dir() {
+        repos.push(Err(Error::from_str("failed to read dir")));
     }
     repos
+}
+
+fn collect_mure_repos(
+    path: &Path,
+    repo_store_path: &Path,
+    repos: &mut Vec<Result<MureRepo, Error>>,
+) {
+    let Ok(dir) = path.read_dir() else {
+        return;
+    };
+    dir.for_each(|entry| {
+        let Ok(entry) = entry else {
+            return;
+        };
+        let entry_path = entry.path();
+        let metadata = match std::fs::symlink_metadata(&entry_path) {
+            Ok(metadata) => metadata,
+            Err(_) => return,
+        };
+        if metadata.is_symlink() {
+            match read_symlink_as_mure_repo(&entry_path) {
+                Ok(mure_repo) => repos.push(Ok(mure_repo)),
+                Err(e) => repos.push(Err(e)),
+            }
+        } else if metadata.is_dir() && entry_path != repo_store_path {
+            collect_mure_repos(&entry_path, repo_store_path, repos);
+        }
+    });
+}
+
+pub fn find_mure_repo(config: &Config, name: &str) -> Result<MureRepo, Error> {
+    let mut matches = search_mure_repo(config)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|mure_repo| {
+            mure_repo.repo.repo == name
+                || mure_repo.repo.name_with_owner() == name
+                || mure_repo.repo.fully_qualified_name() == name
+        })
+        .collect::<Vec<_>>();
+
+    match matches.len() {
+        0 => Err(Error::from_str(
+            format!("{} is not a git repository", name).as_str(),
+        )),
+        1 => Ok(matches.remove(0)),
+        _ => Err(Error::from_str(
+            format!("multiple repositories match {name}; use owner/repo or domain/owner/repo")
+                .as_str(),
+        )),
+    }
 }
 
 fn read_symlink_as_mure_repo(path: &PathBuf) -> Result<MureRepo, Error> {
@@ -167,6 +200,107 @@ mod tests {
             assert_eq!(mure_repo.repo.domain, "github.com");
             assert_eq!(mure_repo.repo.repo, "mure");
         }
+    }
+
+    #[test]
+    fn test_find_mure_repo_by_short_and_full_names() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+
+        let config: Config = toml::from_str(
+            format!(
+                r#"
+            [core]
+            base_dir = "{}"
+
+            [github]
+            username = "kitsuyui"
+
+            [shell]
+            cd_shims = "mucd"
+        "#,
+                temp_dir.to_str().unwrap()
+            )
+            .as_str(),
+        )
+        .unwrap();
+        crate::app::clone::clone(
+            &config,
+            "https://github.com/kitsuyui/mure",
+            Verbosity::Normal,
+        )
+        .unwrap();
+
+        assert_eq!(
+            find_mure_repo(&config, "mure")
+                .unwrap()
+                .repo
+                .fully_qualified_name(),
+            "github.com/kitsuyui/mure"
+        );
+        assert_eq!(
+            find_mure_repo(&config, "kitsuyui/mure")
+                .unwrap()
+                .repo
+                .fully_qualified_name(),
+            "github.com/kitsuyui/mure"
+        );
+        assert_eq!(
+            find_mure_repo(&config, "github.com/kitsuyui/mure")
+                .unwrap()
+                .repo
+                .fully_qualified_name(),
+            "github.com/kitsuyui/mure"
+        );
+    }
+
+    #[test]
+    fn test_find_mure_repo_reports_ambiguous_short_name() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+
+        let config: Config = toml::from_str(
+            format!(
+                r#"
+            [core]
+            base_dir = "{}"
+
+            [github]
+            username = "kitsuyui"
+
+            [shell]
+            cd_shims = "mucd"
+        "#,
+                temp_dir.to_str().unwrap()
+            )
+            .as_str(),
+        )
+        .unwrap();
+        let first_store = config.repo_store_path("github.com", "alice", "project");
+        let second_store = config.repo_store_path("github.com", "bob", "project");
+        std::fs::create_dir_all(first_store.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(second_store.parent().unwrap()).unwrap();
+        git2::Repository::init(&first_store).unwrap();
+        git2::Repository::init(&second_store).unwrap();
+        let first_work = config.repo_work_path("github.com", "alice", "project");
+        let second_work = config.repo_work_path("github.com", "bob", "project");
+        std::fs::create_dir_all(first_work.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(second_work.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&first_store, first_work).unwrap();
+        std::os::unix::fs::symlink(&second_store, second_work).unwrap();
+
+        let Err(err) = find_mure_repo(&config, "project") else {
+            panic!("short repo name should be ambiguous");
+        };
+        assert!(
+            err.to_string()
+                .contains("multiple repositories match project")
+        );
+        assert_eq!(
+            find_mure_repo(&config, "alice/project")
+                .unwrap()
+                .repo
+                .fully_qualified_name(),
+            "github.com/alice/project"
+        );
     }
 
     #[test]

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -17,14 +17,12 @@ fn shell_shims_for_cd_directly(bin_name: &str, fn_name: &str) -> String {
     format!("function {fn_name}() {{ local p=$({bin_name} path \"$1\") && cd \"$p\" }}\n")
 }
 
-fn resolve(config: &Config, name: &str) -> Result<PathBuf, Error> {
+pub(crate) fn resolve(config: &Config, name: &str) -> Result<PathBuf, Error> {
     let path_ = config.base_path().join(name);
     if path_.is_dir() && path_.exists() {
         return Ok(path_);
     }
-    Err(Error::from_str(
-        format!("{} is not a git repository", path_.display()).as_str(),
-    ))
+    crate::app::list::find_mure_repo(config, name).map(|repo| repo.relative_path)
 }
 
 #[cfg(test)]
@@ -67,6 +65,33 @@ mod tests {
                 .to_string()
                 .ends_with("test_repo2 is not a git repository")
         );
+    }
+
+    #[test]
+    fn test_resolve_path_finds_nested_work_symlink() {
+        let temp = Temp::new_dir().unwrap();
+        let config = Config {
+            core: Core {
+                base_dir: temp.as_path().to_str().unwrap().to_string(),
+                editor: None,
+            },
+            github: GitHub {
+                username: "".to_string(),
+                query: None,
+                queries: None,
+            },
+            shell: Some(Shell {
+                cd_shims: Some("mucd".to_string()),
+            }),
+        };
+        let store = config.repo_store_path("github.com", "owner", "test_repo");
+        std::fs::create_dir_all(store.parent().unwrap()).unwrap();
+        git2::Repository::init(&store).unwrap();
+        let work = config.repo_work_path("github.com", "owner", "test_repo");
+        std::fs::create_dir_all(work.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(store, &work).unwrap();
+
+        assert_eq!(resolve(&config, "test_repo").unwrap(), work);
     }
 
     #[test]

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -22,7 +22,9 @@ pub fn refresh_main(
         // If no repository is specified, use the current directory
         let repo_path = get_git_repository_from_current_dir(config)?;
         let repo_path = match repository {
-            Some(repo) => repo,
+            Some(repo) => crate::app::path::resolve(config, &repo)?
+                .to_string_lossy()
+                .to_string(),
             None => repo_path.to_string_lossy().to_string(),
         };
         match refresh(&repo_path, verbosity) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,8 +75,8 @@ impl ConfigSupport for Config {
     fn repo_store_path(&self, domain: &str, owner: &str, repo: &str) -> PathBuf {
         self.repos_store_path().join(domain).join(owner).join(repo)
     }
-    fn repo_work_path(&self, _domain: &str, _owner: &str, repo: &str) -> PathBuf {
-        self.base_path().join(repo)
+    fn repo_work_path(&self, domain: &str, owner: &str, repo: &str) -> PathBuf {
+        self.base_path().join(domain).join(owner).join(repo)
     }
     fn resolve_cd_shims(&self) -> String {
         let default = "mucd".to_string();
@@ -215,6 +215,19 @@ pub mod tests {
         .unwrap();
         assert!(config.core.base_dir == "~/.dev");
         assert_eq!(config.github.username, "kitsuyui");
+    }
+
+    #[test]
+    fn test_repo_work_path_includes_domain_owner_and_repo() {
+        let config = get_test_config();
+        assert_eq!(
+            config.repo_work_path("github.com", "kitsuyui", "mure"),
+            config
+                .base_path()
+                .join("github.com")
+                .join("kitsuyui")
+                .join("mure")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Store working symlinks under `<base>/github.com/<owner>/<repo>` so repositories with the same name from different owners do not collide.
- Resolve repository names through discovered symlinks, keeping short names usable when unique and requiring `owner/repo` or `domain/owner/repo` when ambiguous.
- Route `path`, `edit`, and explicit `refresh` through the resolver and document the nested symlink layout.

## Verification

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `typos`
- `actionlint -shellcheck=`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `git diff --check`
