### PR TITLE
Document .gitignore.in as source-of-truth in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ eval "$(mure completion --shell zsh --cd)"
 
 `mure completion --shell <shell>` also supports other shells such as `bash`, `fish`, `powershell`, and `elvish`.
 
+## Contributing
+
+`.gitignore` is auto-generated from `.gitignore.in` by the daily CI workflow.
+Edit `.gitignore.in` instead of `.gitignore` directly.
+
 ## License
 
 BSD-3-Clause


### PR DESCRIPTION
## Summary

Add a brief Contributing section to README explaining the `.gitignore` / `.gitignore.in` relationship.

- `.gitignore` is auto-generated from `.gitignore.in` by the daily CI workflow
- Contributors should edit `.gitignore.in` directly; edits to `.gitignore` will be overwritten by CI
