### PR TITLE
Return error from open_editor for empty editor string

### DIFF
--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -15,6 +15,9 @@ pub fn edit(config: &Config, repository: String) -> Result<(), Error> {
 }
 
 pub fn open_editor(editor: &str, path: &PathBuf) -> Result<(), Error> {
+    if editor.is_empty() {
+        return Err(Error::from_str("No editor found"));
+    }
     // editor is not only a command name but also can have arguments, so first separate the arguments
     // maybe we can use shlex crate to parse the command and arguments
     let mut editor_args = editor.split_whitespace();
@@ -52,7 +55,9 @@ fn get_editor(config: &Config, path: &PathBuf) -> Result<String, Error> {
 }
 
 fn get_editor_from_config(config: &Config) -> Result<String, Error> {
-    if let Some(editor) = config.core.editor.as_ref() {
+    if let Some(editor) = config.core.editor.as_ref()
+        && !editor.is_empty()
+    {
         return Ok(editor.to_string());
     }
     Err(Error::from_str("No editor found"))
@@ -126,5 +131,22 @@ mod tests {
         std::fs::write(&path, "test_dir").unwrap();
         let result = open_editor("test", &path);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_open_editor_empty_string_returns_error() {
+        let temp = mktemp::Temp::new_dir().unwrap();
+        let path = temp.as_path().join("test_dir");
+        let result = open_editor("", &path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_editor_from_config_empty_string_falls_through() {
+        use crate::config::tests::get_test_config;
+        let mut config = get_test_config();
+        config.core.editor = Some("".to_string());
+        let result = get_editor_from_config(&config);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Problem

When `core.editor` in the mure config file is set to an empty string `""`, two silent failure modes existed:

1. `get_editor_from_config` treated `Some("")` as a valid editor value and returned it, preventing fallback to `git config core.editor` or the `$EDITOR` environment variable.
2. `open_editor` received the empty string and proceeded without error, resulting in a silent no-op — the editor was never opened, and no error was surfaced to the user.

## Fix

Two complementary changes in `src/app/edit.rs`:

**Structural (config layer):** `get_editor_from_config` now checks `!editor.is_empty()` before returning the config value. An empty string in config is treated as absent, allowing the fallback chain to continue.

**Defensive (executor layer):** `open_editor` now returns `Err("No editor found")` immediately when called with an empty string, eliminating the silent success path regardless of how the empty value reached it.

## Tests

Two new unit tests cover the added behaviors:

- `test_open_editor_empty_string_returns_error`: asserts that `open_editor("")` returns `Err`.
- `test_get_editor_from_config_empty_string_falls_through`: asserts that a config with `core.editor = ""` causes `get_editor_from_config` to return `Err`, confirming the fallback is triggered.