### PR TITLE
Propagate pull failure in refresh instead of silently ignoring it

### DIFF
--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -135,34 +135,32 @@ pub fn refresh(repo_path: &str, verbosity: Verbosity) -> Result<RefreshStatus, E
     }
 
     // TODO: origin is hardcoded. If you have multiple remotes, you need to specify which one to use.
-    let result = repo.pull_fast_forwarded("origin", &default_branch);
-    if let Ok(out) = result {
-        match out.interpreted_to {
-            PullFastForwardStatus::AlreadyUpToDate => match verbosity {
-                Verbosity::Quiet => (),
-                Verbosity::Normal => {
-                    messages.push("Already up to date".to_string());
-                }
-                Verbosity::Verbose => {
-                    messages.push("Already up to date".to_string());
-                    messages.push(out.raw.stderr);
-                    messages.push(out.raw.stdout);
-                }
-            },
-            PullFastForwardStatus::FastForwarded => match verbosity {
-                Verbosity::Quiet => (),
-                Verbosity::Normal => {
-                    messages.push("Fast-forwarded".to_string());
-                }
-                Verbosity::Verbose => {
-                    messages.push("Fast-forwarded".to_string());
-                    messages.push(out.raw.stderr);
-                    messages.push(out.raw.stdout);
-                }
-            },
-            _ => (),
-        };
-    }
+    let out = repo.pull_fast_forwarded("origin", &default_branch)?;
+    match out.interpreted_to {
+        PullFastForwardStatus::AlreadyUpToDate => match verbosity {
+            Verbosity::Quiet => (),
+            Verbosity::Normal => {
+                messages.push("Already up to date".to_string());
+            }
+            Verbosity::Verbose => {
+                messages.push("Already up to date".to_string());
+                messages.push(out.raw.stderr);
+                messages.push(out.raw.stdout);
+            }
+        },
+        PullFastForwardStatus::FastForwarded => match verbosity {
+            Verbosity::Quiet => (),
+            Verbosity::Normal => {
+                messages.push("Fast-forwarded".to_string());
+            }
+            Verbosity::Verbose => {
+                messages.push("Fast-forwarded".to_string());
+                messages.push(out.raw.stderr);
+                messages.push(out.raw.stdout);
+            }
+        },
+        _ => (),
+    };
 
     let merged_branches = repo.merged_branches()?.interpreted_to;
     let delete_branches = merged_branches


### PR DESCRIPTION
## Summary

Previously, `refresh` called `pull_fast_forwarded` and discarded errors with `if let Ok(out) = result { ... }`. When the pull failed (e.g., network error, diverged history), the error was silently swallowed and execution continued. This meant merged-branch deletion could run against a potentially stale local state.

## Fix

Replace the silent discard with `?` to propagate the error:

```rust
let out = repo.pull_fast_forwarded("origin", &default_branch)?;
```

## Behavior Change

- **Before**: pull failure was ignored; branch deletion ran on whatever local state was present.
- **After**: pull failure returns `Err` immediately; branch deletion is skipped, preventing accidental deletion decisions based on stale data.
