### PR TITLE
Handle PullFastForwardStatus::Abort explicitly in refresh()

### DIFF
--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -183,7 +183,9 @@ pub fn refresh(repo_path: &str, verbosity: Verbosity) -> Result<RefreshStatus, E
                 messages.push(out.raw.stdout);
             }
         },
-        _ => (),
+        PullFastForwardStatus::Abort => {
+            messages.push("pull aborted: cannot fast-forward".to_string());
+        }
     };
 
     let merged_branches = repo.merged_branches()?.interpreted_to;


### PR DESCRIPTION
## Summary

- Replace `_ => ()` wildcard arm in `refresh()` with an explicit `PullFastForwardStatus::Abort` arm
- When pull cannot fast-forward (local branch has diverged), the function now logs "pull aborted: cannot fast-forward" so users can see when refresh did not update the repository
- Previously this state was silently swallowed and was indistinguishable from `AlreadyUpToDate`

## Test plan

- [ ] All existing tests pass (`cargo test`)
- [ ] `cargo fmt` and `cargo clippy` pass without warnings
- [ ] Run `mure refresh` in a repo where local branch has diverged from remote to verify the message appears