### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: build ${{ matrix.arch }} on ${{ matrix.os }} with ${{ matrix.gcc }}

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- Add top-level `concurrency` to `test.yml` and `octocov.yml` to cancel stale runs on the same branch/PR when a new push arrives
- Add top-level `concurrency` to `binary-release.yml` with `cancel-in-progress` limited to `pull_request` events so release builds are never cancelled

## Verification

```
actionlint -shellcheck="" .github/workflows/test.yml .github/workflows/octocov.yml .github/workflows/binary-release.yml
# no output (all clear)
```

## Trade-offs

- `cancel-in-progress: true` on `test` and `octocov` means any in-progress run on the same ref is cancelled when a new commit is pushed. This is the intended behaviour for PR iteration.
- `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` on `binary-release` preserves running release builds while still cancelling stale PR builds.