### PR TITLE
ci: add cargo-audit job to scan Cargo.lock for known CVEs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit


### PR DESCRIPTION
## Summary

CI (`test.yml`) ran `cargo check`, `cargo test`, `cargo fmt`, `cargo clippy`, and `cargo build` but had no job to scan `Cargo.lock` for known CVEs. Renovate automates version bumps but does not retroactively alert on advisories published after the last update PR.

Added a dedicated `audit` job that installs `cargo-audit` and runs it against the current `Cargo.lock`. This catches advisories in the RustSec Advisory Database for any dependency version that is already pinned in the lock file.

## Change

```yaml
audit:
  name: Security audit
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@<sha> # v6
    - uses: dtolnay/rust-toolchain@<sha> # stable
    - uses: Swatinem/rust-cache@<sha> # v2
    - run: cargo install cargo-audit --locked
    - run: cargo audit
```

Action refs are pinned to the same SHAs already used elsewhere in `test.yml`.

## Validation

- `actionlint`: no issues
