### PR TITLE
Document list and edit subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Generate `.mure.toml` file in home directory.
 ```toml
 [core]
 base_dir = "~/.dev"
+editor = "code"
 
 [github]
 username = "kitsuyui"
@@ -100,6 +101,32 @@ queries = [
 ### mure refresh
 
 `mure refresh` updates the repository.
+
+### mure list
+
+`mure list` shows repositories managed by mure.
+
+```bash
+mure list
+mure list --full
+mure list --path
+mure list --full --path
+```
+
+By default, `mure list` prints repository names. `--full` prints `owner/repository`
+names, `--path` prints relative repository paths, and `--full --path` prints
+absolute repository paths for scripts.
+
+### mure edit
+
+`mure edit <name>` opens a managed repository with an editor.
+
+```bash
+mure edit something
+```
+
+The editor is selected from `core.editor` in `.mure.toml`, Git `core.editor`,
+`EDITOR`, then `VISUAL`.
 
 ### mucd
 


### PR DESCRIPTION
## Summary
- Document the existing `mure list` output modes in `README.md`.
- Document `mure edit <name>` and the editor selection order.
- Add `core.editor` to the sample `.mure.toml` configuration.

## Verification
- `cargo check`
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo audit`
- `git diff --check`
- `typos README.md`
- `actionlint -shellcheck=`
