### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ eval "$(mure completion --shell zsh --cd)"
 `.gitignore` is auto-generated from `.gitignore.in` by the daily CI workflow.
 Edit `.gitignore.in` instead of `.gitignore` directly.
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
+- **pre-push**: the above plus `cargo test`
+
+CI still runs the full suite (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 ## License
 
 BSD-3-Clause

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+
+pre-push:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so developers can run the same fmt/clippy/test checks that CI runs, locally and automatically via Git hooks.
- CI workflows are left completely unchanged.

## Changes

- **`lefthook.yml`** (new): configures two hooks mirroring `.github/workflows/test.yml` exactly:
  - `pre-commit`: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
  - `pre-push`: the above plus `cargo test`
- **`README.md`**: adds a `## Development` section (before `## License`) explaining how to install and use the hooks.

## Verification

All mirrored commands were verified to pass on current code before this PR was opened:

- `cargo fmt --all -- --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test` — 61 passed, 0 failed

The pre-commit hook fired on commit (fmt + clippy) and the pre-push hook fired on push (fmt + clippy + test); both passed cleanly.

## Notes

- Requires `lefthook` on `PATH` (`brew install lefthook` or see https://lefthook.dev/).
- Requires `cargo` / a Rust toolchain.
- Only `lefthook.yml` and `README.md` are modified; no source or CI files are touched.
