### PR TITLE
Add community health files (CONTRIBUTING.md, SECURITY.md, issue templates, PR template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a bug in mure
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. ...
+2. ...
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened (include relevant output or error messages).
+
+**Environment**
+- OS and version:
+- mure version (`mure --version`):
+- Rust version (`rustc --version`):
+
+**Additional context**
+Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for mure
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem or motivation**
+Describe the problem you are trying to solve or the improvement you would like to see.
+
+**Proposed solution**
+Describe the solution you have in mind.
+
+**Alternatives considered**
+Any alternative approaches you have thought about.
+
+**Additional context**
+Any other context or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+## Changes
+
+<!-- List the specific changes made. -->
+
+## Testing
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] `cargo fmt --all -- --check` passes
+
+## Related issues
+
+<!-- Link related issues with "Closes #N" or "Refs #N". -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to mure
+
+Thank you for your interest in contributing to mure, a command-line tool for creating and managing multiple repositories.
+
+## Development Setup
+
+```bash
+git clone https://github.com/kitsuyui/mure.git
+cd mure
+lefthook install   # install pre-commit and pre-push hooks
+```
+
+The project uses [lefthook](https://lefthook.dev/) to run the same checks as CI locally.
+
+## Running Tests and Checks
+
+```bash
+cargo test                      # run tests
+cargo clippy -- -D warnings     # lint
+cargo fmt --all -- --check      # format check
+```
+
+Or let the hooks run automatically when you commit/push.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your changes. Keep each PR focused on one change.
+3. Ensure all tests and clippy checks pass.
+4. Open a pull request against `main` using the provided template.
+
+## Reporting Bugs
+
+Use the bug report issue template. Include your OS, mure version, and steps to reproduce.
+
+## Security Vulnerabilities
+
+See [SECURITY.md](SECURITY.md) for the disclosure process. Do not open a public issue with exploit details.
+
+## Code Style
+
+This project follows standard Rust formatting (`cargo fmt`). Run `cargo fmt` before committing.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the BSD-3-Clause license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled for the latest release and the default branch.
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| Default branch | Best effort |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Please do not open a public issue with exploit details or proof-of-concept code for suspected vulnerabilities.
+
+Use GitHub private vulnerability reporting for this repository when it is available. If it is not available, open a minimal public issue asking for a private disclosure channel, but do not include technical details until a private channel is available.
+
+Please include:
+
+- The affected version or commit.
+- The affected component (CLI, config parsing, GitHub API integration, shell shim, etc.).
+- Reproduction steps or a minimal proof of concept.
+- The expected impact.
+- Relevant OS and environment details.
+
+The maintainer will acknowledge valid reports as soon as practical and will coordinate a fix, release, or advisory when needed.


### PR DESCRIPTION
## Summary

Add the standard community health files that were missing from the repository:

- `CONTRIBUTING.md` — development setup, pre-commit hooks (lefthook), test/lint commands, PR workflow, and a pointer to `SECURITY.md`.
- `SECURITY.md` — supported versions and private vulnerability disclosure instructions.
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug report template asking for OS, mure version, Rust version, and reproduction steps.
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template.
- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist covering `cargo test`, `cargo clippy`, and `cargo fmt`.

## Changes

- Added `CONTRIBUTING.md` with dev setup, lefthook instructions, and PR workflow.
- Added `SECURITY.md` with supported versions and disclosure process.
- Added `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`.
- Added `.github/PULL_REQUEST_TEMPLATE.md` with a Rust check checklist.

## Testing

No source code changes; markdown-only additions. Pre-commit hooks (lefthook) and CI are unaffected.